### PR TITLE
Fix size_t compile bug with GCC 11.1

### DIFF
--- a/AudioCodecs.hh
+++ b/AudioCodecs.hh
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stddef.h>
 
 #include <vector>
 


### PR DESCRIPTION
Attempting to compile with GCC 11.1 yields this error:
```
In file included from AudioCodecs.cc:1:
AudioCodecs.hh:5:55: error: ‘size_t’ has not been declared
    5 | std::vector<int16_t> decode_mace(const uint8_t* data, size_t size, bool stereo,
      |                                                       ^~~~~~
AudioCodecs.hh:7:55: error: ‘size_t’ has not been declared
    7 | std::vector<int16_t> decode_ima4(const uint8_t* data, size_t size, bool stereo);
      |                                                       ^~~~~~
AudioCodecs.hh:8:55: error: ‘size_t’ has not been declared
    8 | std::vector<int16_t> decode_alaw(const uint8_t* data, size_t size);
      |                                                       ^~~~~~
AudioCodecs.hh:9:55: error: ‘size_t’ has not been declared
    9 | std::vector<int16_t> decode_ulaw(const uint8_t* data, size_t size);
      |                                                       ^~~~~~
make: *** [<builtin>: AudioCodecs.o] Error 1
```

The proposed change fixes it.