### PR TITLE
Fix build error for hypercard_dasm.cc

### DIFF
--- a/hypercard_dasm.cc
+++ b/hypercard_dasm.cc
@@ -63,7 +63,7 @@ string autoformat_hypertalk(const string& src) {
 
       // lowercase the line for pseudo-parsing
       string lowercase_line = line;
-      transform(lowercase_line.begin(), lowercase_line.end(), lowercase_line.begin(), tolower);
+      transform(lowercase_line.begin(), lowercase_line.end(), lowercase_line.begin(), ::tolower);
       size_t comment_start = lowercase_line.find("--");
       if (comment_start != string::npos) {
         lowercase_line.resize(comment_start);


### PR DESCRIPTION
Got the following build error with `g++ (Gentoo 10.2.0-r5 p6) 10.2.0` for file `hypercard_dasm.cc`:

```
hypercard_dasm.cc: In function ‘std::string autoformat_hypertalk(const string&)’:
hypercard_dasm.cc:66:94: error: no matching function for call to ‘transform(std::__cxx11::basic_string<char>::iterator, std::__cxx11::basic_string<char>::iterator, std::__cxx11::basic_string<char>::iterator, <unresolved overloaded function type>)’
   66 |       transform(lowercase_line.begin(), lowercase_line.end(), lowercase_line.begin(), tolower);
      |                                                                                              ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/include/g++-v10/functional:65,
                 from /usr/include/phosg/Filesystem.hh:15,
                 from hypercard_dasm.cc:9:
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/include/g++-v10/bits/stl_algo.h:4302:5: note: candidate: ‘template<class _IIter, class _OIter, class _UnaryOperation> _OIter std::transform(_IIter, _IIter, _OIter, _UnaryOperation)’
 4302 |     transform(_InputIterator __first, _InputIterator __last,
      |     ^~~~~~~~~
```

The proposed code change fixes it.