### PR TITLE
On HFS+ all files have resource forks, so check the size as well

### DIFF
--- a/src/resource_dasm.cc
+++ b/src/resource_dasm.cc
@@ -1795,16 +1795,14 @@ private:
 
   bool disassemble_file(const string& filename) {
     // open resource fork if present
-    string resource_fork_filename;
-    if (this->use_data_fork) {
-      resource_fork_filename = filename;
-    } else if (isfile(filename + RESOURCE_FORK_FILENAME_SUFFIX)) {
-      resource_fork_filename = filename + RESOURCE_FORK_FILENAME_SUFFIX;
-    } else if (isfile(filename + RESOURCE_FORK_FILENAME_SHORT_SUFFIX)) {
-      resource_fork_filename = filename + RESOURCE_FORK_FILENAME_SHORT_SUFFIX;
-    } else {
-      fprintf(stderr, "failed on %s: no resource fork present\n", filename.c_str());
-      return false;
+    string resource_fork_filename = filename;
+    if (!this->use_data_fork) {
+      resource_fork_filename += RESOURCE_FORK_FILENAME_SUFFIX;
+      // On HFS+, the resource fork always exists, but might be empty. On APFS, the resource fork is optional
+      if (!isfile(resource_fork_filename) || stat(resource_fork_filename).st_size == 0) {
+        fprintf(stderr, "failed on %s: resource fork missing or empty\n", filename.c_str());
+        return false;
+      }
     }
 
     // compute the base filename


### PR DESCRIPTION
Contrary to APFS, where the resource fork is optional, on HFS+ files always have a resource fork. So don't only check for its existance, but also that it's not empty.

Also removed the shorter `/rsrc` form of accessing the resource fork, as it [was deprecated in MacOS 10.4 and removed in 10.7](https://en.wikipedia.org/wiki/Resource_fork#How_a_resource_fork_is_accessed), and is equivalent to the longer form anyway. It's still recognized when used in the output file name, though. This might not be necessary, depending on whether backwards compatibility with older resource_dasm versions is important or not.