### PR TITLE
Correctly decode positioning of ALRT, DLOG and WIN

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 
 ### Bugs
 
-* Sometimes WINDs fail to decode with the system template with the error "skip beyond end of string"
+*
 
 ### Code style
 

--- a/src/ResourceFile.cc
+++ b/src/ResourceFile.cc
@@ -937,6 +937,13 @@ static void disassemble_from_template_inner(
         }
         break;
       }
+      
+      case Type::OPT_EOF:
+        if (!r.eof()) {
+          disassemble_from_template_inner(lines, r, entry->list_entries, indent_level);
+        }
+        break;
+      
       default:
         throw logic_error("unknown field type in disassemble_from_template");
     }

--- a/src/ResourceFile.hh
+++ b/src/ResourceFile.hh
@@ -681,6 +681,7 @@ public:
       LIST_ZERO_COUNT, // ZCNT+LSTC+LSTE (count is a word)
       LIST_ONE_COUNT, // OCNT+LSTC+LSTE (count is a word)
       LIST_EOF, // LSTB+LSTE
+      OPT_EOF, // If there's still data left
     };
     enum class Format {
       DECIMAL,

--- a/src/SystemTemplates.cc
+++ b/src/SystemTemplates.cc
@@ -106,6 +106,10 @@ static shared_ptr<Entry> t_list_one_count(const char* name, EntryList&& entries)
   return shared_ptr<Entry>(new Entry(name, Type::LIST_ONE_COUNT, move(entries)));
 }
 
+static shared_ptr<Entry> t_opt_eof(EntryList&& entries) {
+  return shared_ptr<Entry>(new Entry("", Type::OPT_EOF, move(entries)));
+}
+
 static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_templates({
   {RESOURCE_TYPE_acur, {
     t_word("Number of frames (cursors)", false),
@@ -148,8 +152,11 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
       t_bool("(1) snd high"),
       t_bool("(1) snd low"),
     }),
-    // Seems to be present in only some resources:
-    // t_word_hex("Auto position")
+    t_opt_eof({
+      // Can exist in System 7.0 and later
+      t_align(2),
+      t_word_hex("Auto position", false),
+    })
   }},
   {RESOURCE_TYPE_APPL, {
     t_list_eof("Entries", {
@@ -246,9 +253,12 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
     t_bool("GoAway"),
     t_long("RefCon"),
     t_word("ItemsID"),
-    t_pstring("Title"),
-    // Seems to be present in only some resources:
-    // t_word_hex("Auto position")
+    t_pstring("Title", false),
+    t_opt_eof({
+      // Can exist in System 7.0 and later
+      t_align(2),
+      t_word_hex("Auto position", false),
+    })
   }},
   {RESOURCE_TYPE_errs, {
     t_list_eof("Entries", {
@@ -877,9 +887,12 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
     t_bool("Visible"),
     t_bool("GoAway"),
     t_long("RefCon"),
-    t_pstring("Title", true),
-    // Seems to be present in only some resources:
-    // t_word_hex("Auto position")
+    t_pstring("Title", false),
+    t_opt_eof({
+      // Can exist in System 7.0 and later
+      t_align(2),
+      t_word_hex("Auto position", false),
+    })
   }},
   {RESOURCE_TYPE_wstr, {
     t_pstring_2("String"),


### PR DESCRIPTION
Starting with System 7, ALRT, DLOG and WIND resources can contain an additional word (correctly aligned) with the alert/dialog/window's positioning (none, center on main screen, stagger relative to parent window etc). To correctly decode this, I added a TMPL type for optional data at the end of the resource.

Left to do: decide how to display the value for positioning, as there are only a few valid ones (see Rez header file `Types.r`).