### PR TITLE
Disassemble MacsBug symbols

### DIFF
--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -3383,20 +3383,182 @@ const M68KEmulator::OpcodeImplementation M68KEmulator::fns[0x10] = {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+
+static bool is_valid_macsbug_symbol_char(char ch) {
+  // "Building and Managing Programs in MPW", chapter B-25:
+  //
+  //    A valid MacsBug symbol consists of _ characters, % characters, spaces,
+  //    digits, and uppercase and lowercase letters
+  //
+  // "Macsbug Reference and Debugging Guide", page 367:
+  //
+  //    Valid characters for procedure names are a–z, A–Z, 0–9, underscore (_), 
+  //    percent (%), period (.), and space
+  
+  // Do not use 'isalpha' etc. as they take the current locale into account
+  return  ch == '_' ||
+          ch == '%' ||
+          ch == '.' ||
+          ch == ' ' ||
+          (ch >= '0' && ch <= '9') ||
+          (ch >= 'A' && ch <= 'Z') ||
+          (ch >= 'a' && ch <= 'z');
+}
+
+
+static bool try_decode_macsbug_symbol_part(StringReader& r, string& symbol, uint16_t symbol_length) {
+  if (r.remaining() < symbol_length) {
+    return false;
+  }
+  
+  for (uint16_t i = 0; i < symbol_length; ++i) {
+    uint8_t ch = r.get_u8();
+    if (!is_valid_macsbug_symbol_char(ch)) {
+      return false;
+    }
+    symbol += ch;
+  }
+  
+  return true;
+}
+
+
+static bool try_decode_macsbug_symbol(StringReader& r, string& symbol, uint16_t& num_constants) {
+
+  // All indented comments are from "Macsbug Reference and Debugging Guide", page 367,
+  // and "Building and Managing Programs in MPW", page B-25f
+  
+  symbol.clear();
+  num_constants = 0;
+  
+  if (r.remaining() < 2) {
+    return false;
+  }
+  
+  uint32_t  start = r.where();
+  uint8_t   symbol_0 = r.get_u8();
+  uint8_t   symbol_1 = r.get_u8();
+  uint8_t   symbol_0_low7 = symbol_0 & 0x7F;
+  uint8_t   symbol_1_low7 = symbol_1 & 0x7F;
+  
+  //    With fixed-length format, the first byte is in the range $20 through $7F.
+  //    The high-order bit may or may not be set.
+  
+  if (symbol_0_low7 >= 0x20 && symbol_0_low7 <= 0x7F) {
+    //    The high-order bit of the second byte is set for 16-character names,
+    //    clear for 8-character names. Fixed-length 16-character names are used
+    //    in object Pascal to show class.method names instead of procedure names.
+    //    The method name is contained in the first 8 bytes and the class name is
+    //    in the second 8 bytes. MacsBug swaps the order and inserts the period
+    //    before displaying the name.
+    
+    if (is_valid_macsbug_symbol_char(symbol_0_low7) && is_valid_macsbug_symbol_char(symbol_1_low7)) {
+      symbol += symbol_0_low7;
+      symbol += symbol_1_low7;
+      
+      if (symbol_1 & 0x80) {
+        if (try_decode_macsbug_symbol_part(r, symbol, 16 - 2)) {
+          symbol = symbol.substr(8, 8) + "." + symbol.substr(0, 8);
+          return true;
+        }
+      } else {
+        if (try_decode_macsbug_symbol_part(r, symbol, 8 - 2)) {
+          return true;
+        }
+      }
+    }
+  } else if (symbol_0 >= 0x80 && symbol_0 <= 0x9F) {
+    //    With variable-length format, the first byte is in the range $80 to $9F.
+    //    Stripping the high-order bit produces a length in the range $00 through
+    //    $1F. If the length is 0, the next byte contains the actual length, in
+    //    the range $01 through $FF [otherwise the next byte is the name's first
+    //    character]. Data after the name starts on a word boundary.
+    
+    uint16_t  symbol_length = symbol_0_low7;
+    bool      valid = true;
+    if (symbol_length == 0) {
+      symbol_length = symbol_1;
+    }
+    else if (is_valid_macsbug_symbol_char(symbol_1)) {
+      symbol += symbol_1;
+      --symbol_length;
+    }
+    else {
+      valid = false;
+    }
+    
+    if (valid && try_decode_macsbug_symbol_part(r, symbol, symbol_length)) {
+      if (r.where() & 1) {
+        //    Data after the name starts on a word boundary.
+        r.skip(1);
+      }
+  
+      //    Compilers can place a procedure’s constant data immediately after
+      //    the procedure in memory. The first word after the name specifies
+      //    how many bytes of constant data are present. If there are no
+      //    constants, a length of 0 must be given.
+      
+      num_constants = r.get_u16b();
+      // TODO: unclear if this necessary, or if the size of the constants is always even
+      if (num_constants & 1) {
+        ++num_constants;
+      }
+      return true;
+    }
+  }
+  
+  // No MacsBug symbol
+  r.go(start);
+  
+  return false;
+}
+
+
 string M68KEmulator::disassemble_one(StringReader& r, uint32_t start_address,
-    map<uint32_t, bool>& branch_target_addresses) {
+    map<uint32_t, bool>& branch_target_addresses, bool& prev_was_return) {
   size_t opcode_offset = r.where();
   string opcode_disassembly;
-  try {
-    uint8_t op_high = r.get_u8(false);
-    opcode_disassembly = M68KEmulator::fns[(op_high >> 4) & 0x000F].dasm(r,
-        start_address, branch_target_addresses);
-  } catch (const out_of_range&) {
-    if (r.where() == opcode_offset) {
-      // There must be at least 1 byte available since r.eof() was false
-      r.get_u8();
+  if (prev_was_return) {
+    string        symbol;
+    std::uint16_t num_constants;
+    if (try_decode_macsbug_symbol(r, symbol, num_constants)) {
+      // We have a MacsBug symbol plus additional constant data
+      // TODO: decode type/length of symbol like ResEdit/Resorcerer do?
+      opcode_disassembly = string_printf("dc.b '%s'", symbol.c_str());
+      
+      if (num_constants > 0) {
+        // TODO: disassemble constants instead of skipping them
+        opcode_disassembly += string_printf(" + %u constant bytes", num_constants);
+        r.skip(num_constants);
+      }
     }
-    opcode_disassembly = ".incomplete";
+    prev_was_return = false;
+  }
+  if (opcode_disassembly.empty()) {
+    // Didn't decode any MacsBug symbol: disassemble instruction
+    if (uint16_t op = r.get_u16b(false); op == 0x4E75 /*RTS*/ || op == 0x4E74 /*RTD*/ || op == 0x4ED0 /*JMP (A0)*/) {
+      // "Macsbug Reference and Debugging Guide", page 367:
+      //
+      //    A procedure is defined as follows:
+      //    ...
+      //     -  Procedure code
+      //     -  RTS or JMP(A0) or RTD
+      //    ...
+    
+      prev_was_return = true;
+    }
+  
+    try {
+      uint8_t op_high = r.get_u8(false);
+      opcode_disassembly = M68KEmulator::fns[(op_high >> 4) & 0x000F].dasm(r,
+          start_address, branch_target_addresses);
+    } catch (const out_of_range&) {
+      if (r.where() == opcode_offset) {
+        // There must be at least 1 byte available since r.eof() was false
+        r.get_u8();
+      }
+      opcode_disassembly = ".incomplete";
+    }
   }
 
   string line;
@@ -3414,8 +3576,15 @@ string M68KEmulator::disassemble_one(StringReader& r, uint32_t start_address,
       // This should only happen for .incomplete at the end of the stream
       hex_data += string_printf(" %02X  ", r.get_u8());
     }
-    while (hex_data.size() < 25) {
-      hex_data += "     ";
+    if (hex_data.size() > 25) {
+      // This should only happen for MacsBug symbols
+      hex_data.resize(22);
+      hex_data += "...";
+      
+    } else {
+      while (hex_data.size() < 25) {
+        hex_data += "     ";
+      }
     }
     line += hex_data;
   }
@@ -3429,7 +3598,8 @@ string M68KEmulator::disassemble_one(const void* vdata, size_t size,
     uint32_t start_address) {
   StringReader r(vdata, size);
   map<uint32_t, bool> branch_target_addresses;
-  return M68KEmulator::disassemble_one(r, start_address, branch_target_addresses);
+  bool prev_was_return;
+  return M68KEmulator::disassemble_one(r, start_address, branch_target_addresses, prev_was_return);
 }
 
 string M68KEmulator::disassemble(const void* vdata, size_t size,
@@ -3444,11 +3614,12 @@ string M68KEmulator::disassemble(const void* vdata, size_t size,
 
   // Phase 1: generate the disassembly for each opcode, and collect branch
   // target addresses
-  StringReader r(vdata, size);
+  StringReader  r(vdata, size);
+  bool          prev_was_return = false;
   while (!r.eof()) {
     uint32_t pc = r.where() + start_address;
     string line = string_printf("%08" PRIX32 " ", pc);
-    line += M68KEmulator::disassemble_one(r, start_address, branch_target_addresses);
+    line += M68KEmulator::disassemble_one(r, start_address, branch_target_addresses, prev_was_return);
     line += '\n';
     uint32_t next_pc = r.where() + start_address;
     lines.emplace(pc, make_pair(move(line), next_pc));
@@ -3486,10 +3657,11 @@ string M68KEmulator::disassemble(const void* vdata, size_t size,
     uint32_t pc = branch_start_pc;
     r.go(pc - start_address);
 
+    prev_was_return = false;
     while (!lines.count(pc) && !r.eof()) {
       string line = string_printf("%08" PRIX32 " ", pc);
       map<uint32_t, bool> temp_branch_target_addresses;
-      line += M68KEmulator::disassemble_one(r, start_address, temp_branch_target_addresses);
+      line += M68KEmulator::disassemble_one(r, start_address, temp_branch_target_addresses, prev_was_return);
       line += '\n';
       uint32_t next_pc = r.where() + start_address;
       lines.emplace(pc, make_pair(move(line), next_pc));

--- a/src/Emulators/M68KEmulator.hh
+++ b/src/Emulators/M68KEmulator.hh
@@ -99,7 +99,8 @@ public:
   static std::string disassemble_one(
       StringReader& r,
       uint32_t start_address,
-      std::map<uint32_t, bool>& branch_target_addresses);
+      std::map<uint32_t, bool>& branch_target_addresses,
+      bool& prev_was_return);
   static std::string disassemble_one(
       const void* vdata,
       size_t size,


### PR DESCRIPTION
The 68k disassembler now disassembles the optional symbol at the end of a function. It also skips any constant data following after the symbol. This also reduces the amount of "alternate branches" and ".incomplete" in the disassembler's output.

Tested via resource_dasm on several applications that use the new symbol format. The old formats are untested, but should work.

Left to do:
- Disassemble the constant data as one/several lines of `dc.w xxxx` instead of skipping it, like ResEdit and Resorcerer do. I'm not sure if it's ok with you to return several lines from `disassemble_one`.
- Use the symbol names instead of anonymous labels. I don't pretend to quite understand how the labelling currently works ;-)