### PR TITLE
Decode OSType as MacRoman

### DIFF
--- a/src/ResourceFile.cc
+++ b/src/ResourceFile.cc
@@ -39,7 +39,7 @@ string string_for_resource_type(uint32_t type) {
     uint8_t ch = (type >> s) & 0xFF;
     if (ch == '\\') {
       result += "\\\\";
-    } else if (ch >= 0 && ch < 0x20) {
+    } else if (unsigned(ch) < 0x20) {
       result += string_printf("\\x%02hhX", ch);
     } else {
       result += decode_mac_roman(ch);
@@ -685,8 +685,8 @@ static void disassemble_from_template_inner(
             static_cast<char>((value >> 8) & 0xFF),
             static_cast<char>(value & 0xFF)
           };
-          if ((ch[0] >= 0 && ch[0] < 0x20) || (ch[1] >= 0 && ch[1] < 0x20) ||
-              (ch[2] >= 0 && ch[2] < 0x20) || (ch[3] >= 0 && ch[3] < 0x20)) {
+          if ((unsigned(ch[0]) < 0x20) || (unsigned(ch[1]) < 0x20) ||
+              (unsigned(ch[2]) < 0x20) || (unsigned(ch[3]) < 0x20)) {
             return string_printf("0x%08" PRIX64, value);
           } else {
             return string_printf("\'%s\' (0x%08" PRIX64 ")", decode_mac_roman(ch, 4).c_str(), value);

--- a/src/ResourceFile.hh
+++ b/src/ResourceFile.hh
@@ -962,6 +962,7 @@ private:
 
 std::string decode_mac_roman(const char* data, size_t size);
 std::string decode_mac_roman(const std::string& data);
+std::string decode_mac_roman(char data);
 
 const char* name_for_region_code(uint16_t region_code);
 const char* name_for_font_id(uint16_t font_id);

--- a/src/resource_dasm.cc
+++ b/src/resource_dasm.cc
@@ -48,8 +48,8 @@ static constexpr char FILENAME_FORMAT_TYPE_FIRST_DIRS[] = "%t/%f/%i%n";
 
 
 
-static constexpr bool should_escape_filename_char(char ch) {
-  return (ch < 0x20) || (ch > 0x7E) || (ch == '/') || (ch == ':');
+static constexpr bool should_escape_mac_roman_filename_char(char ch) {
+  return (ch >= 0 && ch < 0x20) || (ch == '/') || (ch == ':');
 }
 
 
@@ -158,10 +158,10 @@ private:
     uint32_t filtered_type = res->type;
     for (size_t x = 0; x < 4; x++) {
       char ch = filtered_type >> ((3 - x) * 8);
-      if (should_escape_filename_char(ch)) {
+      if (should_escape_mac_roman_filename_char(ch)) {
         type_str += string_printf("_x%02hhX", ch);
       } else {
-        type_str += ch;
+        type_str += decode_mac_roman(ch);
       }
     }
 
@@ -172,10 +172,10 @@ private:
     if (!res->name.empty()) {
       name_token = '_';
       for (char ch : res->name) {
-        if (should_escape_filename_char(ch)) {
+        if (should_escape_mac_roman_filename_char(ch)) {
           name_token += '_';
         } else {
-          name_token += ch;
+          name_token += decode_mac_roman(ch);
         }
       }
     }

--- a/src/resource_dasm.cc
+++ b/src/resource_dasm.cc
@@ -49,7 +49,7 @@ static constexpr char FILENAME_FORMAT_TYPE_FIRST_DIRS[] = "%t/%f/%i%n";
 
 
 static constexpr bool should_escape_mac_roman_filename_char(char ch) {
-  return (ch >= 0 && ch < 0x20) || (ch == '/') || (ch == ':');
+  return (unsigned(ch) < 0x20) || (ch == '/') || (ch == ':');
 }
 
 


### PR DESCRIPTION
Instead of treating characters outside of ASCII-7 as invalid for decoding and filenames, decode them using MacRoman:

1. OSTypes e.g. in FREF. Decoded FREF old: `File type: 0x93436F6E`; new: `File type: 'ìCon' (0x93436F6E)`.
2. Resource type in the output filename. Old: `Icon Dearchiver 4.0.app__x93Dea_0.bin`; new: `Icon Dearchiver 4.0.app_ìDea_0.bin`.