### PR TITLE
Better error message when rendering PICTs with unknown QuickTime codec

### DIFF
--- a/src/QuickDrawEngine.cc
+++ b/src/QuickDrawEngine.cc
@@ -1022,8 +1022,9 @@ void QuickDrawEngine::pict_write_quicktime_data(StringReader& r, uint16_t opcode
     } else if (desc.codec == 0x74696666) { // kTIFFCodecType
       throw pict_contains_undecodable_quicktime("tiff", move(encoded_data));
     } else {
+      string codec = string_for_resource_type(desc.codec.load());
       throw runtime_error(string_printf(
-          "compressed QuickTime data uses codec '%s' [0x%08" PRIX32 "]", string_for_resource_type(desc.codec.load()).c_str(), desc.codec.load()));
+          "compressed QuickTime data uses codec '%s' [0x%08" PRIX32 "]", codec.c_str(), desc.codec.load()));
     }
 
     if (decoded.get_width() != this->port->width() || decoded.get_height() != this->port->height()) {

--- a/src/QuickDrawEngine.cc
+++ b/src/QuickDrawEngine.cc
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "QuickDrawFormats.hh"
+#include "ResourceFile.hh"      // For string_for_resource_type
 
 using namespace std;
 
@@ -1022,7 +1023,7 @@ void QuickDrawEngine::pict_write_quicktime_data(StringReader& r, uint16_t opcode
       throw pict_contains_undecodable_quicktime("tiff", move(encoded_data));
     } else {
       throw runtime_error(string_printf(
-          "compressed QuickTime data uses codec %08" PRIX32, desc.codec.load()));
+          "compressed QuickTime data uses codec '%s' [0x%08" PRIX32 "]", string_for_resource_type(desc.codec.load()).c_str(), desc.codec.load()));
     }
 
     if (decoded.get_width() != this->port->width() || decoded.get_height() != this->port->height()) {


### PR DESCRIPTION
Format the QuickTime codec's OSType as a string, not a number. Before: `(compressed QuickTime data uses codec 57524C45)`; after: `(compressed QuickTime data uses codec 'WRLE' [0x57524C45])`.

The inclusion of `ResourceFile.hh` just for `string_for_resource_type` is a bit ugly; these conversion-to-string functions should probably get their own file.