### PR TITLE
New templates for audt, dbex, mach, flst, fmap, glby, lstr, mitq…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ resource_dasm can convert these resource types:
       finf | .txt (description of contents)                          |
       FCMT | .txt                                                    | *3
       FONT | .txt (description) and .bmp (one image per glyph)       |
+      lstr | .txt                                                    | *3
       MACS | .txt                                                    | *3
       minf | .txt                                                    | *3
       mstr | .txt                                                    | *3
@@ -229,21 +230,26 @@ resource_dasm can convert these resource types:
     Miscellaneous resources
       ALRT | .txt (alert parameters)                                 |
       APPL | .txt (description of contents)                          |
+      audt | .txt (description of contents)                          |
       BNDL | .txt (description of contents)                          |
       CMDK | .txt (list of keys)                                     |
       CMNU | .txt (description of menu)                              |
       cmnu | .txt (description of menu)                              |
       CNTL | .txt (description of control)                           |
       CTY# | .txt (description of cities)                            |
+      dbex | .txt (description of contents)                          |
       DITL | .txt (dialog parameters)                                |
       DLOG | .txt (dialog parameters)                                |
       errs | .txt (description of error ranges)                      |
       FBTN | .txt (description of buttons)                           |
       FDIR | .txt (description of contents)                          |
       fld# | .txt (description of folders)                           |
+      flst | .txt (description of font family list)                  |
+      fmap | .txt (description of finder icon mappings)              |
       FREF | .txt (description of file references)                   |
       FRSV | .txt (list of font IDs)                                 |
       FWID | .txt (font parameters)                                  |
+      gbly | .txt (description of Gibbly aka. System Enabler)        |
       GNRL | .txt (description of contents)                          |
       hwin | .txt (description of help window)                       |
       icmt | .txt (icon reference and comment)                       |
@@ -253,30 +259,40 @@ resource_dasm can convert these resource types:
       inpk | .txt (description of contents)                          |
       inra | .txt (description of contents)                          |
       insc | .txt (description of contents)                          |
+      itl0 | .txt (international formatting information)             |
       ITL1 | .txt (short dates flag value)                           |
       itlb | .txt (internationalization parameters)                  |
       itlc | .txt (internationalization parameters)                  |
       itlk | .txt (keyboard mappings)                                |
       KBDN | .txt (keyboard name)                                    |
       LAYO | .txt (description of layout)                            |
+      mach | .txt (description of contents)                          |
       MBAR | .txt (list of menu IDs)                                 |
       mcky | .txt (threshold values)                                 |
       MENU | .txt (description of menu)                              |
+      mitq | .txt (description of queue sizes)                       |
       nrct | .txt (rectangle boundaries)                             |
       PAPA | .txt (printer parameters)                               |
       PICK | .txt (picker parameters)                                |
       ppcc | .txt (description of contents)                          |
+      ppci | .txt (description of contents)                          |
       PRC0 | .txt (description of contents)                          |
       PRC3 | .txt (description of contents)                          |
+      pslt | .txt (description of Nubus pseudo-slot lists)           |
+      ptbl | .txt (description of patch table)                       |
       qrsc | .txt (description of queries)                           |
+      RECT | .txt (description of the rectangle)                     |
       resf | .txt (list of fonts)                                    |
       RMAP | .txt (type mapping and list of ID exceptions)           |
       ROv# | .txt (list of overridden resource IDs)                  |
+      rtt# | .txt (list of database result handlers)                 |
       RVEW | .txt (description of contents)                          |
       scrn | .txt (screen device parameters)                         |
       sect | .txt (description of contents)                          |
       SIGN | .txt (description of contents)                          |
       SIZE | .txt (description of parameters)                        |
+      slut | .txt (description of mapping)                           |
+      thn# | .txt (description of 'thng' mapping)                    |
       TMPL | .txt (description of format)                            |
       TOOL | .txt (description of contents)                          |
       vers | .txt (version flags and strings)                        |

--- a/src/ResourceFile.hh
+++ b/src/ResourceFile.hh
@@ -43,6 +43,7 @@ constexpr uint32_t RESOURCE_TYPE_alis = resource_type("alis");
 constexpr uint32_t RESOURCE_TYPE_ALRT = resource_type("ALRT");
 constexpr uint32_t RESOURCE_TYPE_APPL = resource_type("APPL");
 constexpr uint32_t RESOURCE_TYPE_atlk = resource_type("atlk");
+constexpr uint32_t RESOURCE_TYPE_audt = resource_type("audt");
 constexpr uint32_t RESOURCE_TYPE_BNDL = resource_type("BNDL");
 constexpr uint32_t RESOURCE_TYPE_boot = resource_type("boot");
 constexpr uint32_t RESOURCE_TYPE_bstr = resource_type("bstr");
@@ -70,6 +71,7 @@ constexpr uint32_t RESOURCE_TYPE_csnd = resource_type("csnd");
 constexpr uint32_t RESOURCE_TYPE_CTBL = resource_type("CTBL");
 constexpr uint32_t RESOURCE_TYPE_CTYN = resource_type("CTY#");
 constexpr uint32_t RESOURCE_TYPE_CURS = resource_type("CURS");
+constexpr uint32_t RESOURCE_TYPE_dbex = resource_type("dbex");
 constexpr uint32_t RESOURCE_TYPE_dcmp = resource_type("dcmp");
 constexpr uint32_t RESOURCE_TYPE_dcod = resource_type("dcod");
 constexpr uint32_t RESOURCE_TYPE_dctb = resource_type("dctb");
@@ -94,11 +96,14 @@ constexpr uint32_t RESOURCE_TYPE_FDIR = resource_type("FDIR");
 constexpr uint32_t RESOURCE_TYPE_finf = resource_type("finf");
 constexpr uint32_t RESOURCE_TYPE_FKEY = resource_type("FKEY");
 constexpr uint32_t RESOURCE_TYPE_fldN = resource_type("fld#");
+constexpr uint32_t RESOURCE_TYPE_flst = resource_type("flst");
+constexpr uint32_t RESOURCE_TYPE_fmap = resource_type("fmap");
 constexpr uint32_t RESOURCE_TYPE_FONT = resource_type("FONT");
 constexpr uint32_t RESOURCE_TYPE_fovr = resource_type("fovr");
 constexpr uint32_t RESOURCE_TYPE_FREF = resource_type("FREF");
 constexpr uint32_t RESOURCE_TYPE_FRSV = resource_type("FRSV");
 constexpr uint32_t RESOURCE_TYPE_FWID = resource_type("FWID");
+constexpr uint32_t RESOURCE_TYPE_gbly = resource_type("gbly");
 constexpr uint32_t RESOURCE_TYPE_gcko = resource_type("gcko");
 constexpr uint32_t RESOURCE_TYPE_GDEF = resource_type("GDEF");
 constexpr uint32_t RESOURCE_TYPE_gdef = resource_type("gdef");
@@ -152,6 +157,7 @@ constexpr uint32_t RESOURCE_TYPE_insc = resource_type("insc");
 constexpr uint32_t RESOURCE_TYPE_INST = resource_type("INST");
 constexpr uint32_t RESOURCE_TYPE_is32 = resource_type("is32");
 constexpr uint32_t RESOURCE_TYPE_it32 = resource_type("it32");
+constexpr uint32_t RESOURCE_TYPE_itl0 = resource_type("itl0");
 constexpr uint32_t RESOURCE_TYPE_ITL1 = resource_type("ITL1");
 constexpr uint32_t RESOURCE_TYPE_itlb = resource_type("itlb");
 constexpr uint32_t RESOURCE_TYPE_itlc = resource_type("itlc");
@@ -166,7 +172,9 @@ constexpr uint32_t RESOURCE_TYPE_LAYO = resource_type("LAYO");
 constexpr uint32_t RESOURCE_TYPE_LDEF = resource_type("LDEF");
 constexpr uint32_t RESOURCE_TYPE_lmgr = resource_type("lmgr");
 constexpr uint32_t RESOURCE_TYPE_lodr = resource_type("lodr");
+constexpr uint32_t RESOURCE_TYPE_lstr = resource_type("lstr");
 constexpr uint32_t RESOURCE_TYPE_ltlk = resource_type("ltlk");
+constexpr uint32_t RESOURCE_TYPE_mach = resource_type("mach");
 constexpr uint32_t RESOURCE_TYPE_MACS = resource_type("MACS");
 constexpr uint32_t RESOURCE_TYPE_MADH = resource_type("MADH");
 constexpr uint32_t RESOURCE_TYPE_MADI = resource_type("MADI");
@@ -179,6 +187,7 @@ constexpr uint32_t RESOURCE_TYPE_MIDI = resource_type("MIDI");
 constexpr uint32_t RESOURCE_TYPE_Midi = resource_type("Midi");
 constexpr uint32_t RESOURCE_TYPE_midi = resource_type("midi");
 constexpr uint32_t RESOURCE_TYPE_minf = resource_type("minf");
+constexpr uint32_t RESOURCE_TYPE_mitq = resource_type("mitq");
 constexpr uint32_t RESOURCE_TYPE_mntr = resource_type("mntr");
 constexpr uint32_t RESOURCE_TYPE_MOOV = resource_type("MOOV");
 constexpr uint32_t RESOURCE_TYPE_MooV = resource_type("MooV");
@@ -211,6 +220,7 @@ constexpr uint32_t RESOURCE_TYPE_pltt = resource_type("pltt");
 constexpr uint32_t RESOURCE_TYPE_pnll = resource_type("pnll");
 constexpr uint32_t RESOURCE_TYPE_ppat = resource_type("ppat");
 constexpr uint32_t RESOURCE_TYPE_ppcc = resource_type("ppcc");
+constexpr uint32_t RESOURCE_TYPE_ppci = resource_type("ppci");
 constexpr uint32_t RESOURCE_TYPE_ppct = resource_type("ppct");
 constexpr uint32_t RESOURCE_TYPE_PPic = resource_type("PPic");
 constexpr uint32_t RESOURCE_TYPE_pptN = resource_type("ppt#");
@@ -218,15 +228,19 @@ constexpr uint32_t RESOURCE_TYPE_PRC0 = resource_type("PRC0");
 constexpr uint32_t RESOURCE_TYPE_PRC3 = resource_type("PRC3");
 constexpr uint32_t RESOURCE_TYPE_proc = resource_type("proc");
 constexpr uint32_t RESOURCE_TYPE_PSAP = resource_type("PSAP");
+constexpr uint32_t RESOURCE_TYPE_pslt = resource_type("pslt");
+constexpr uint32_t RESOURCE_TYPE_ptbl = resource_type("ptbl");
 constexpr uint32_t RESOURCE_TYPE_PTCH = resource_type("PTCH");
 constexpr uint32_t RESOURCE_TYPE_ptch = resource_type("ptch");
 constexpr uint32_t RESOURCE_TYPE_pthg = resource_type("pthg");
 constexpr uint32_t RESOURCE_TYPE_qrsc = resource_type("qrsc");
 constexpr uint32_t RESOURCE_TYPE_qtcm = resource_type("qtcm");
+constexpr uint32_t RESOURCE_TYPE_RECT = resource_type("RECT");
 constexpr uint32_t RESOURCE_TYPE_resf = resource_type("resf");
 constexpr uint32_t RESOURCE_TYPE_RMAP = resource_type("RMAP");
 constexpr uint32_t RESOURCE_TYPE_ROvN = resource_type("ROv#");
 constexpr uint32_t RESOURCE_TYPE_ROvr = resource_type("ROvr");
+constexpr uint32_t RESOURCE_TYPE_rttN = resource_type("rtt#");
 constexpr uint32_t RESOURCE_TYPE_RVEW = resource_type("RVEW");
 constexpr uint32_t RESOURCE_TYPE_s8mk = resource_type("s8mk");
 constexpr uint32_t RESOURCE_TYPE_sb24 = resource_type("sb24");
@@ -245,6 +259,7 @@ constexpr uint32_t RESOURCE_TYPE_sift = resource_type("sift");
 constexpr uint32_t RESOURCE_TYPE_SIGN = resource_type("SIGN");
 constexpr uint32_t RESOURCE_TYPE_SIZE = resource_type("SIZE");
 constexpr uint32_t RESOURCE_TYPE_slct = resource_type("slct");
+constexpr uint32_t RESOURCE_TYPE_slut = resource_type("slut");
 constexpr uint32_t RESOURCE_TYPE_SMOD = resource_type("SMOD");
 constexpr uint32_t RESOURCE_TYPE_SMSD = resource_type("SMSD");
 constexpr uint32_t RESOURCE_TYPE_snd  = resource_type("snd ");
@@ -257,6 +272,7 @@ constexpr uint32_t RESOURCE_TYPE_styl = resource_type("styl");
 constexpr uint32_t RESOURCE_TYPE_t8mk = resource_type("t8mk");
 constexpr uint32_t RESOURCE_TYPE_tdig = resource_type("tdig");
 constexpr uint32_t RESOURCE_TYPE_TEXT = resource_type("TEXT");
+constexpr uint32_t RESOURCE_TYPE_thnN = resource_type("thn#");
 constexpr uint32_t RESOURCE_TYPE_TMPL = resource_type("TMPL");
 constexpr uint32_t RESOURCE_TYPE_TOC  = resource_type("TOC ");
 constexpr uint32_t RESOURCE_TYPE_tokn = resource_type("tokn");
@@ -718,7 +734,7 @@ public:
     bool is_signed;
 
     std::vector<std::shared_ptr<TemplateEntry>> list_entries;
-    std::map<int32_t, std::string> case_names;
+    std::map<int64_t, std::string> case_names;
 
     TemplateEntry(std::string&& name,
         Type type,
@@ -726,7 +742,8 @@ public:
         uint16_t width = 0,
         uint8_t end_alignment = 0,
         uint8_t align_offset = 0,
-        bool is_signed = true);
+        bool is_signed = true,
+        std::map<int64_t, std::string> case_names = {});
     TemplateEntry(std::string&& name,
         Type type,
         std::vector<std::shared_ptr<TemplateEntry>>&& list_entries);

--- a/src/SystemTemplates.cc
+++ b/src/SystemTemplates.cc
@@ -612,6 +612,7 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
       // 0 = parenthesis, 1 = minus sign
       t_bool("Negative representation"),
       t_bool("Currency symbol leads number"),
+      // 4 unused bits
     }),
     t_byte("Short date format order", false, {
       { 0, "month/day/year" },
@@ -625,6 +626,7 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
       t_bool("Short date has century"),
       t_bool("Short date's month has leading 0"),
       t_bool("Short date's day has leading 0"),
+      // 5 unused bits
     }),
     t_char("Short date separator"),
     t_byte("Time cycle short date", false, {
@@ -636,6 +638,7 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
       t_bool("Leading 0 in hours"),
       t_bool("Leading 0 in minutes"),
       t_bool("Leading 0 in seconds"),
+      // 5 unused bits
     }),
     t_string("Morning string", 4),
     t_string("Evening string", 4),

--- a/src/SystemTemplates.cc
+++ b/src/SystemTemplates.cc
@@ -196,9 +196,6 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
   {RESOURCE_TYPE_audt, {
     t_list_eof("Entries", {
       t_ostype("Macintosh model"),
-      // 0 = not installed
-      // 1 = minimal installation
-      // 2 = full installation
       t_long("Installation status", false, {
         { 0, "not installed" },
         { 1, "minimal installation" },
@@ -934,11 +931,12 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
   }},
   {RESOURCE_TYPE_pslt, {
     t_word("Number of Nubus pseudo-slots"),
-    // 0 = Horizontal form factor, ascending slot order   
-    // 1 = Horizontal form factor, descending slot order  
-    // 2 = Vertical form factor, ascending slot order     
-    // 3 = Vertical form factor, descending slot order
-    t_word("Nubus orientation"),
+    t_word("Nubus orientation", {
+      { 0, "Horizontal form factor, ascending slot order" },
+      { 1, "Horizontal form factor, descending slot order" },
+      { 2, "Vertical form factor, ascending slot order" },
+      { 3, "Vertical form factor, descending slot order" },
+    }),
     t_list_eof("Slots", {
       t_word("Nubus slot"),
       t_word("Pseudo slot"),

--- a/src/SystemTemplates.cc
+++ b/src/SystemTemplates.cc
@@ -934,7 +934,7 @@ static const unordered_map<uint32_t, ResourceFile::TemplateEntryList> system_tem
   }},
   {RESOURCE_TYPE_pslt, {
     t_word("Number of Nubus pseudo-slots"),
-    t_word("Nubus orientation", {
+    t_word("Nubus orientation", false, {
       { 0, "Horizontal form factor, ascending slot order" },
       { 1, "Horizontal form factor, descending slot order" },
       { 2, "Vertical form factor, ascending slot order" },

--- a/src/resource_dasm.cc
+++ b/src/resource_dasm.cc
@@ -291,7 +291,7 @@ private:
             if (!entry->case_names.empty()) {
               vector<string> tokens;
               for (const auto& case_name : entry->case_names) {
-                tokens.emplace_back(string_printf("%" PRId32 " = %s", case_name.first, case_name.second.c_str()));
+                tokens.emplace_back(string_printf("%" PRId64 " = %s", case_name.first, case_name.second.c_str()));
               }
               case_names_str = " (" + join(tokens, ", ") + ")";
             }


### PR DESCRIPTION
New templates for audt, dbex, mach, flst, fmap, glby, lstr, mitq, RECT, slut (ahem), thn#, ppci, pslt, ptbl, rtt# and itl0 resources
Strings in labeled TMPL-entry are surrounded by '' like single characters and OSTypes
Actually use `case_names` when formatting an integer
Change `case_names` key to 64 bit, so it works with 32 bit unsigned integers