### PR TITLE
Improvements to readability of TMPL lists (YMMV):

### DIFF
--- a/src/ResourceFile.cc
+++ b/src/ResourceFile.cc
@@ -688,12 +688,12 @@ static void format_list_item(deque<string>& lines, StringReader& r, const shared
   if (temp_lines.size() == 1) {
     string last = temp_lines.back();
     strip_leading_whitespace(last);
-    temp_lines.back() = item_prefix + " " + last;
+    lines.emplace_back(item_prefix + " " + last);
   } else {
     lines.emplace_back(item_prefix);
-  }
-  for (const string& l : temp_lines) {
-    lines.emplace_back(l);
+    for (const string& l : temp_lines) {
+      lines.emplace_back(l);
+    }
   }
 };
 

--- a/src/ResourceFile.cc
+++ b/src/ResourceFile.cc
@@ -560,6 +560,13 @@ ResourceFile::TemplateEntryList ResourceFile::decode_TMPL(const void* data, size
   return ret;
 }
 
+
+static void disassemble_from_template_inner(
+    deque<string>& lines,
+    StringReader& r,
+    const ResourceFile::TemplateEntryList& entries,
+    size_t indent_level);
+
 static string format_template_string(ResourceFile::TemplateEntry::Format format, const string& str, bool has_name) {
   using Entry = ResourceFile::TemplateEntry;
   using Format = Entry::Format;
@@ -668,6 +675,27 @@ static string format_template_bool(shared_ptr<const ResourceFile::TemplateEntry>
   
   return (value ? "true" : "false") + case_name_suffix;
 }
+
+static void format_list_item(deque<string>& lines, StringReader& r, const shared_ptr<const ResourceFile::TemplateEntry>& entry, size_t indent_level, size_t z) {
+  deque<string> temp_lines;
+  disassemble_from_template_inner(temp_lines, r, entry->list_entries, indent_level + 1);
+  
+  string item_prefix(indent_level * 2, ' ');
+  item_prefix += string_printf("%zu:", z);
+  
+  // When the inner template is a single line, prefix it with the array index.
+  // Otherwise put the array index on its own line
+  if (temp_lines.size() == 1) {
+    string last = temp_lines.back();
+    strip_leading_whitespace(last);
+    temp_lines.back() = item_prefix + " " + last;
+  } else {
+    lines.emplace_back(item_prefix);
+  }
+  for (const string& l : temp_lines) {
+    lines.emplace_back(l);
+  }
+};
 
 static void disassemble_from_template_inner(
     deque<string>& lines,
@@ -864,19 +892,13 @@ static void disassemble_from_template_inner(
       case Type::LIST_ZERO_BYTE:
         lines.emplace_back(prefix + "(zero-terminated list)");
         for (size_t z = 0; r.get_u8(false); z++) {
-          string item_prefix(indent_level * 2, ' ');
-          item_prefix += entry->name;
-          lines.emplace_back(item_prefix + string_printf("[%zu]", z));
-          disassemble_from_template_inner(lines, r, entry->list_entries, indent_level + 1);
+          format_list_item(lines, r, entry, indent_level + 1, z);
         }
         break;
       case Type::LIST_EOF:
         lines.emplace_back(prefix + "(EOF-terminated list)");
         for (size_t z = 0; !r.eof(); z++) {
-          string item_prefix(indent_level * 2, ' ');
-          item_prefix += entry->name;
-          lines.emplace_back(item_prefix + string_printf("[%zu]", z));
-          disassemble_from_template_inner(lines, r, entry->list_entries, indent_level + 1);
+          format_list_item(lines, r, entry, indent_level + 1, z);
         }
         break;
       case Type::LIST_ZERO_COUNT:
@@ -900,10 +922,7 @@ static void disassemble_from_template_inner(
         }
         lines.emplace_back(prefix + string_printf("(%zu entries)", num_items));
         for (size_t z = 0; z < num_items; z++) {
-          string item_prefix(indent_level * 2, ' ');
-          item_prefix += entry->name;
-          lines.emplace_back(item_prefix + string_printf("[%zu]", z));
-          disassemble_from_template_inner(lines, r, entry->list_entries, indent_level + 1);
+          format_list_item(lines, r, entry, indent_level + 1, z);
         }
         break;
       }


### PR DESCRIPTION
Don't repeat array name in array element for better readability. Old:
```
Items: (8 entries)
  Items[0]
    Bounds: x1=218, y1=132, x2=288, y2=150
    Type: 4
    Info: 'Save'
  Items[1]
    Bounds: x1=218, y1=158, x2=288, y2=176
    Type: 4
    Info: 'Cancel'
```
New:
```
Items: (8 entries)
  0:
    Bounds: x1=218, y1=132, x2=288, y2=150
    Type: 4
    Info: 'Save'
  1:
    Bounds: x1=218, y1=158, x2=288, y2=176
    Type: 4
    Info: 'Cancel'
```

Put single-line array elements on the same line as the array index for better readability. Old:
```
Number of frames (cursors): 8
Used frame counter: 0
Frames: (EOF-terminated list)
  0:
    CURS resource ID: 4
  1:
    CURS resource ID: -6078
  2:
    CURS resource ID: -6077
...
```
New:
```
Number of frames (cursors): 8
Used frame counter: 0
Frames: (EOF-terminated list)
  0: CURS resource ID: 4
  1: CURS resource ID: -6078
  2: CURS resource ID: -6077
  3: CURS resource ID: -6076
...
```