### PR TITLE
Skip unknown icns chunks instead of throwing an error

### DIFF
--- a/src/ResourceFile.cc
+++ b/src/ResourceFile.cc
@@ -2229,7 +2229,8 @@ ResourceFile::DecodedIconImagesResource ResourceFile::decode_icns(const void* da
           break;
         default:
           string type_str = string_for_resource_type(sec_type);
-          throw runtime_error("unknown section type " + type_str);
+          fprintf(stderr, "Warning: unknown section type in icns: %s\n", type_str.c_str());
+          break;
       }
     } catch (const exception& e) {
       string type_str = string_for_resource_type(sec_type);


### PR DESCRIPTION
While the icon won't be fully decoded, at least the parts that resource_dasm understands will.

To do: decode the unknown chunks (taken from [libicns](https://icns.sourceforge.io)):
- "tile": tile variant
- "over": rollover variant
- "drop": drop variant
- "open": open variant
- "odrp": open drop variant