### PR TITLE
More flexible selection of resource types and IDs

### DIFF
--- a/src/Cli.hh
+++ b/src/Cli.hh
@@ -11,9 +11,11 @@ uint32_t parse_cli_type(const char* str, char end_char = '\0', size_t* num_chars
 //
 //  <id>
 //  <min id>..<max id>
+//  ~<id>
+//  ~<min id>..<max id>
 //
 // Both <min id> and <max id> are optional and default to -32768 and 32767,
-// respectively.
+// respectively. The prefix `~` complements the ID(s).
 //
 void parse_cli_ids(const char* str, ResourceIDs& ids);
 

--- a/src/ResourceFile.cc
+++ b/src/ResourceFile.cc
@@ -208,6 +208,12 @@ shared_ptr<const ResourceFile::Resource> ResourceFile::get_resource(
   throw out_of_range("no such resource");
 }
 
+const std::string& ResourceFile::get_resource_name(
+  uint32_t type, int16_t id) const {
+  
+  return this->key_to_resource.at(this->make_resource_key(type, id))->name;
+}
+
 vector<int16_t> ResourceFile::all_resources_of_type(uint32_t type) const {
   vector<int16_t> ret;
   for (auto it = this->key_to_resource.lower_bound(this->make_resource_key(type, 0));

--- a/src/ResourceFile.hh
+++ b/src/ResourceFile.hh
@@ -369,6 +369,7 @@ public:
   // with decompression_flags = DecompressionFlag::DISABLED.
   std::shared_ptr<const Resource> get_resource(uint32_t type, int16_t id) const;
   std::shared_ptr<const Resource> get_resource(uint32_t type, const char* name) const;
+  const std::string& get_resource_name(uint32_t type, int16_t id) const;
   std::vector<int16_t> all_resources_of_type(uint32_t type) const;
   std::vector<uint32_t> all_resource_types() const;
   std::vector<std::pair<uint32_t, int16_t>> all_resources() const;

--- a/src/ResourceIDs.hh
+++ b/src/ResourceIDs.hh
@@ -10,10 +10,13 @@ constexpr int MAX_RES_ID = 32767;
 // A set of resource IDs
 class ResourceIDs {
   public:
-    explicit ResourceIDs(bool all_included = false) : bits() {
-      if (all_included) {
-        this->bits.set();
-      }
+    enum class Init {
+      ALL,
+      NONE,
+    };
+    
+    explicit ResourceIDs(Init init) : bits() {
+      this->reset(init);
     }
     
     bool operator[](int res_id) const {
@@ -30,12 +33,21 @@ class ResourceIDs {
       return *this;
     }
     
-    void reset(bool all_included) {
-      if (all_included) {
+    ResourceIDs& operator-=(const ResourceIDs& res_ids) {
+      this->bits &= ~res_ids.bits;
+      return *this;
+    }
+    
+    void reset(Init init) {
+      if (init == Init::ALL) {
         this->bits.set();
       } else {
         this->bits.reset();
       }
+    }
+    
+    bool empty() const {
+      return this->bits.none();
     }
     
     void print(FILE* file, bool new_line) const;

--- a/src/dupe_finder.cc
+++ b/src/dupe_finder.cc
@@ -69,9 +69,13 @@ Duplicate resources finder input options:\n\
       The optional IDs are a comma-separated list of single IDs or ID\n\
       ranges, where an ID range has the format <min id>..<max id>. Both\n\
       <min id> and <max_id> are optional and default to -32768 and\n\
-      32767, respectively.\n\
-      For example, --target=PICT:128,1000..2000,..-12345 limits the check\n\
-      to PICT resources with IDs -32768 to -12345, 128, and 1000 to 2000.\n\
+      32767, respectively. Prefixing an ID [range] with '~' (the tilde)\n\
+      excludes instead of includes.\n\
+      For example, --target=PICT:128,1000..2000,~1234,..-12345 limits the check\n\
+      to PICT resources with IDs -32768 to -12345, 128, and 1000 to 2000,\n\
+      except for ID 1234.\n\
+      Another example: --target=CODE:~0 exports only CODE resources with\n\
+      an ID other than 0.\n\
   --delete\n\
       Delete duplicate resources WITHOUT PROMPTING FOR CONFIRMATION.\n\
   --backup\n\
@@ -103,7 +107,7 @@ int main(int argc, const char** argv) {
         } else if (!strcmp(argv[x], "--backup")) {
           make_backup = true;
         } else if (!strncmp(argv[x], "--target=", 9)) {
-          ResourceIDs ids;
+          ResourceIDs ids(ResourceIDs::Init::NONE);
           uint32_t    type = parse_cli_type_ids(&argv[x][9], &ids);
           input_res_types.emplace(type, ids);
         } else {
@@ -138,7 +142,7 @@ int main(int argc, const char** argv) {
     if (input_res_types.empty()) {
       for (const InputFile& file : input_files) {
         for (uint32_t type : file.resources.all_resource_types()) {
-          input_res_types.emplace(type, ResourceIDs(true));
+          input_res_types.emplace(type, ResourceIDs(ResourceIDs::Init::ALL));
         }
       }
     }


### PR DESCRIPTION
- resource_dasm now supports ID ranges. This probably changed the interactions between resource_dasm's various include/exclude options a bit. Honestly, I think they have become too complicated and should be simplified in some way.

- IDs/ID ranges can be excluded instead of included by prefixing them with `~` (`!` can't be used because it clashes with the shell's history expansion).

- ResourceIDs's constructor takes an `enum` instead of a `bool` to get rid of unwanted implicit conversions (e.g. from pointers) to `bool`.