### PR TITLE
Fix for #53

### DIFF
--- a/src/Emulators/MemoryContext.cc
+++ b/src/Emulators/MemoryContext.cc
@@ -190,7 +190,7 @@ MemoryContext::Arena::~Arena() {
 }
 
 string MemoryContext::Arena::str() const {
-  string ret = string_printf("[Arena %08" PRIX32 "-%08lX at %p alloc=%zX free=%zX alloc_blocks=[",
+  string ret = string_printf("[Arena %08" PRIX32 "-%08zX at %p alloc=%zX free=%zX alloc_blocks=[",
       this->addr,
       this->addr + this->size,
       this->host_addr,


### PR DESCRIPTION
If only clang warned when using the wrong printf format even when it's accidentally correct (such as `%lX` on a platform where `size_t` happens to have the same size as `unsigned long`)...