### PR TITLE
Specify location of phosg library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,14 @@ list(APPEND CMAKE_PREFIX_PATH ${LOCAL_LIB_DIR})
 include_directories(${LOCAL_INCLUDE_DIR})
 link_directories(${LOCAL_LIB_DIR})
 
-find_package(phosg REQUIRED)
+# phosg library in custom location?
+if (PHOSG_DIR)
+  # (requires symlink "phosg" -> "src" in phosg directory)
+  include_directories(${PHOSG_DIR})
+  link_directories(${PHOSG_DIR})
+else()
+  find_package(phosg REQUIRED)
+endif()
 
 
 


### PR DESCRIPTION
This is mainly for myself, but might be useful to others. The symlink requirement is unfortunate, but could be remedied by renaming phosg's `src` directory to `phosg`.