### PR TITLE
Add note decay info to SONG resource exports

### DIFF
--- a/src/ResourceFile.cc
+++ b/src/ResourceFile.cc
@@ -3840,6 +3840,7 @@ static ResourceFile::DecodedSongResource decode_SONG_SMS(
   ret.volume_bias = 127;
   ret.semitone_shift = header.semitone_shift;
   ret.percussion_instrument = header.percussion_instrument;
+  ret.note_decay = header.note_decay;
   ret.allow_program_change = (header.flags1 & SMSSongResourceHeader::Flags1::ENABLE_MIDI_PROGRAM_CHANGE);
   for (size_t x = 0; x < header.instrument_override_count; x++) {
     const auto& override = r.get<SMSSongResourceHeader::InstrumentOverride>();
@@ -3867,6 +3868,7 @@ static ResourceFile::DecodedSongResource decode_SONG_RMF(
   ret.tempo_bias = header.tempo_bias;
   ret.volume_bias = header.volume_bias;
   ret.semitone_shift = header.semitone_shift;
+  ret.note_decay = -1;
   ret.percussion_instrument = -1;
   ret.allow_program_change = true;
 

--- a/src/ResourceFile.hh
+++ b/src/ResourceFile.hh
@@ -249,6 +249,7 @@ public:
     uint16_t volume_bias; // base = 127; linear
     int16_t semitone_shift;
     int16_t percussion_instrument; // -1 = unspecified (RMF)
+    int16_t note_decay; // In 1/60ths; -1 = unspecified
     bool allow_program_change;
     std::unordered_map<uint16_t, uint16_t> instrument_overrides;
 

--- a/src/resource_dasm.cc
+++ b/src/resource_dasm.cc
@@ -1699,6 +1699,9 @@ private:
     if (s && s->tempo_bias && (s->tempo_bias != 16667)) {
       base_dict.emplace("tempo_bias", static_cast<double>(s->tempo_bias) / 16667.0);
     }
+    if (s && s->note_decay && (s->note_decay != -1)) {
+      base_dict.emplace("note_decay", s->note_decay);
+    }
     if (s && s->percussion_instrument) {
       base_dict.emplace("percussion_instrument", s->percussion_instrument);
     }


### PR DESCRIPTION
`SMSSongResourceHeader` already parses the global note decay information contained in SONG resources, but this wasn't being saved anywhere. This PR adds this field to the JSON representation of SONG resources. I just used the native format for this - decay in 1/60ths of a second - but could convert that to seconds here instead if you think that makes more sense.