### PR TITLE
Fix six 68K/PPC emulator bugs/gaps

### DIFF
--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -2855,7 +2855,7 @@ void M68KEmulator::exec_E(uint16_t opcode) {
     }
   } else {
     shift_amount = (a == 0) ? 8 : a;
-    if (shift_amount == 8 && size == SIZE_BYTE) {
+    if (shift_amount == 8 && size == SIZE_BYTE && ((k & 6) != 4)) { // roxl/roxr handle a byte count of 8 below
       throw std::runtime_error("unimplemented: shift opcode with size=byte and shift=8");
     }
   }
@@ -2872,6 +2872,38 @@ void M68KEmulator::exec_E(uint16_t opcode) {
       bool left_shift = (k & 1);
       bool logical_shift = (k & 2);
       bool rotate = (k & 4);
+
+      if (rotate && !logical_shift) { // roxl/roxr DREG, COUNT/REG
+        // Rotate through the X bit: the operand and X together form a (bits + 1)-bit rotate, so the effective count
+        // is the count modulo (bits + 1). The register form uses Dn mod 64 before that reduction.
+        uint8_t bits = bytes_for_size[size] * 8;
+        uint32_t mask = (size == SIZE_LONG) ? 0xFFFFFFFF : ((1 << bits) - 1);
+        uint8_t count = shift_is_reg ? (this->regs.d[a].u & 0x3F) : shift_amount;
+        uint32_t v = this->regs.d[Xn].u & mask;
+        bool x = this->regs.sr.get_x();
+        int64_t x_flag;
+        int64_t c_flag;
+        if (count == 0) {
+          // A count of zero leaves X unchanged and sets C to X (unlike the other shift/rotate opcodes)
+          x_flag = -1;
+          c_flag = x;
+        } else {
+          for (uint8_t z = count % (bits + 1); z > 0; z--) {
+            bool new_x = left_shift ? ((v >> (bits - 1)) & 1) : (v & 1);
+            if (left_shift) {
+              v = ((v << 1) | x) & mask;
+            } else {
+              v = (v >> 1) | (static_cast<uint32_t>(x) << (bits - 1));
+            }
+            x = new_x;
+          }
+          x_flag = x;
+          c_flag = x;
+        }
+        this->regs.d[Xn].u = (this->regs.d[Xn].u & (~mask)) | v;
+        this->regs.set_ccr_flags(x_flag, (v >> (bits - 1)) & 1, (v == 0), 0, c_flag);
+        return;
+      }
 
       if (shift_amount == 0) {
         this->regs.set_ccr_flags(-1, is_negative(this->regs.d[Xn].u, SIZE_LONG), (this->regs.d[Xn].u == 0), 0, 0);

--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -1591,7 +1591,12 @@ void M68KEmulator::exec_4(uint16_t opcode) {
             return;
           }
           case 3: { // not.S ADDR
-            uint32_t value = ~static_cast<int32_t>(this->read(addr, size));
+            uint32_t value = ~this->read(addr, size);
+            if (size == SIZE_BYTE) {
+              value &= 0xFF;
+            } else if (size == SIZE_WORD) {
+              value &= 0xFFFF;
+            }
             this->write(addr, value, size);
             this->regs.set_ccr_flags(-1, is_negative(value, size), (value == 0), 0, 0);
             return;

--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -2305,7 +2305,15 @@ void M68KEmulator::exec_8(uint16_t opcode) {
   } else { // or.S DREG ADDR
     this->regs.d[a].u = value;
   }
-  this->regs.set_ccr_flags(-1, is_negative(value, size), (value == 0), 0, 0);
+  // For byte/word sizes, value contains the bits of Dn above the operation size; those bits are correctly preserved
+  // by the register writeback above, but must not affect the flags
+  uint32_t sized_value = value;
+  if (size == SIZE_BYTE) {
+    sized_value &= 0xFF;
+  } else if (size == SIZE_WORD) {
+    sized_value &= 0xFFFF;
+  }
+  this->regs.set_ccr_flags(-1, is_negative(sized_value, size), (sized_value == 0), 0, 0);
 }
 
 std::string M68KEmulator::dasm_8(DisassemblyState& s) {

--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -2057,25 +2057,30 @@ void M68KEmulator::exec_5(uint16_t opcode) {
     }
 
   } else { // subq/addq ADDR, IMM
-    // TODO: when dealing with address registers, size is ignored according to the manual. Implement this.
-    auto addr = this->resolve_address(M, Xn, size);
     uint8_t value = op_get_a(opcode);
     if (value == 0) {
       value = 8;
     }
 
-    // Note: ccr flags are skipped when operating on an A register (M == 1)
+    if (M == 1) {
+      // When the destination is an address register, the entire 32-bit register is used regardless of
+      // the operation size, and the condition codes are not affected.
+      if (op_get_g(opcode)) {
+        this->regs.a[Xn] -= value;
+      } else {
+        this->regs.a[Xn] += value;
+      }
+      return;
+    }
+
+    auto addr = this->resolve_address(M, Xn, size);
     uint32_t mem_value = this->read(addr, size);
     if (op_get_g(opcode)) {
+      this->regs.set_ccr_flags_integer_subtract(mem_value, value, size);
       this->write(addr, mem_value - value, size);
-      if (M != 1) {
-        this->regs.set_ccr_flags_integer_subtract(mem_value, value, size);
-      }
     } else {
+      this->regs.set_ccr_flags_integer_add(mem_value, value, size);
       this->write(addr, mem_value + value, size);
-      if (M != 1) {
-        this->regs.set_ccr_flags_integer_add(mem_value, value, size);
-      }
     }
     this->regs.set_ccr_flags(this->regs.sr.get_c(), -1, -1, -1, -1);
   }

--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -570,30 +570,67 @@ int32_t M68KEmulator::fetch_instruction_data_signed(uint8_t size, bool advance) 
   return data;
 }
 
-uint32_t M68KEmulator::resolve_address_extension(uint16_t ext) {
+uint32_t M68KEmulator::resolve_address_extension(uint32_t base, uint16_t ext) {
+  // base is the base register's value: An for mode-6 references, or the address of the extension word itself for
+  // PC-relative references. The full effective address is returned (not an offset from base), since the 68020
+  // memory-indirect forms dereference an intermediate address.
   bool is_a_reg = ext & 0x8000;
   uint8_t reg_num = static_cast<uint8_t>((ext >> 12) & 7);
   bool index_is_word = !(ext & 0x0800);
   uint8_t scale = 1 << ((ext >> 9) & 3);
 
-  int32_t disp_reg_value = this->regs.get_reg_value(is_a_reg, reg_num);
+  int32_t index = this->regs.get_reg_value(is_a_reg, reg_num);
   if (index_is_word) {
     // Word index: use only the low 16 bits of the register, sign-extended. The high word is ignored; it commonly holds
     // stale data after a move.w
-    disp_reg_value = static_cast<int32_t>(static_cast<int16_t>(disp_reg_value & 0xFFFF));
+    index = static_cast<int32_t>(static_cast<int16_t>(index & 0xFFFF));
   }
-  uint32_t ret = disp_reg_value * scale;
+  index *= scale;
+
   if (!(ext & 0x0100)) {
-    // Brief extension word
-    // TODO: is this signed? here we're assuming it is
-    int8_t offset = static_cast<int8_t>(ext & 0xFF);
-    ret += offset;
-    return ret;
+    // Brief extension word: base + index + 8-bit signed displacement
+    return base + index + static_cast<int8_t>(ext & 0xFF);
   }
 
-  // Full extension word
-  // TODO: implement this. See page 43 in the programmers' manual
-  throw std::runtime_error("unimplemented: full extension word");
+  // Full extension word (68020+). The base and index registers can each be suppressed, the base and outer
+  // displacements can each be null, word, or long, and memory can be indirected before or after indexing:
+  //   No memory indirect:   base + bd + index
+  //   Preindexed indirect:  read_u32(base + bd + index) + od
+  //   Postindexed indirect: read_u32(base + bd) + index + od
+  if (ext & 0x0040) { // Index suppress
+    index = 0;
+  }
+  if (ext & 0x0080) { // Base suppress
+    base = 0;
+  }
+  uint8_t bd_size = (ext >> 4) & 3;
+  int32_t bd = 0;
+  if (bd_size == 2) {
+    bd = this->fetch_instruction_data_signed(SIZE_WORD);
+  } else if (bd_size == 3) {
+    bd = this->fetch_instruction_data_signed(SIZE_LONG);
+  }
+
+  uint8_t i_is = ext & 7;
+  if (i_is == 0) { // No memory indirect action
+    return base + bd + index;
+  }
+  if (i_is == 4) {
+    throw std::runtime_error("invalid full extension word (I/IS = 4)");
+  }
+
+  // The low 2 bits of I/IS give the outer displacement size; bit 2 selects postindexed (1) or preindexed (0)
+  int32_t od = 0;
+  if ((i_is & 3) == 2) {
+    od = this->fetch_instruction_data_signed(SIZE_WORD);
+  } else if ((i_is & 3) == 3) {
+    od = this->fetch_instruction_data_signed(SIZE_LONG);
+  }
+  if (i_is & 4) { // Postindexed
+    return this->read(base + bd, SIZE_LONG) + index + od;
+  } else { // Preindexed
+    return this->read(base + bd + index, SIZE_LONG) + od;
+  }
 }
 
 uint32_t M68KEmulator::resolve_address_control(uint8_t M, uint8_t Xn) {
@@ -603,7 +640,7 @@ uint32_t M68KEmulator::resolve_address_control(uint8_t M, uint8_t Xn) {
     case 5:
       return this->regs.a[Xn] + this->fetch_instruction_word_signed();
     case 6:
-      return this->regs.a[Xn] + this->resolve_address_extension(this->fetch_instruction_word());
+      return this->resolve_address_extension(this->regs.a[Xn], this->fetch_instruction_word());
     case 7: {
       switch (Xn) {
         case 0:
@@ -616,7 +653,7 @@ uint32_t M68KEmulator::resolve_address_control(uint8_t M, uint8_t Xn) {
         }
         case 3: {
           uint32_t orig_pc = this->regs.pc;
-          return orig_pc + this->resolve_address_extension(this->fetch_instruction_word());
+          return this->resolve_address_extension(orig_pc, this->fetch_instruction_word());
         }
         default:
           throw std::runtime_error("incorrect address mode in control reference");
@@ -646,7 +683,7 @@ M68KEmulator::ResolvedAddress M68KEmulator::resolve_address(uint8_t M, uint8_t X
     case 5:
       return {this->regs.a[Xn] + this->fetch_instruction_word_signed(), ResolvedAddress::Location::MEMORY};
     case 6:
-      return {this->regs.a[Xn] + this->resolve_address_extension(this->fetch_instruction_word()),
+      return {this->resolve_address_extension(this->regs.a[Xn], this->fetch_instruction_word()),
           ResolvedAddress::Location::MEMORY};
     case 7: {
       switch (Xn) {
@@ -656,9 +693,11 @@ M68KEmulator::ResolvedAddress M68KEmulator::resolve_address(uint8_t M, uint8_t X
           return {this->fetch_instruction_data(SIZE_LONG), ResolvedAddress::Location::MEMORY};
         case 2:
           return {this->regs.pc + this->fetch_instruction_word_signed(), ResolvedAddress::Location::MEMORY};
-        case 3:
-          return {this->regs.pc + this->resolve_address_extension(this->fetch_instruction_word()),
+        case 3: {
+          uint32_t orig_pc = this->regs.pc;
+          return {this->resolve_address_extension(orig_pc, this->fetch_instruction_word()),
               ResolvedAddress::Location::MEMORY};
+        }
         case 4:
           if (size == SIZE_LONG) {
             this->regs.pc += 4;

--- a/src/Emulators/M68KEmulator.hh
+++ b/src/Emulators/M68KEmulator.hh
@@ -210,7 +210,7 @@ private:
   uint32_t fetch_instruction_data(uint8_t size, bool advance = true);
   int32_t fetch_instruction_data_signed(uint8_t size, bool advance = true);
 
-  uint32_t resolve_address_extension(uint16_t ext);
+  uint32_t resolve_address_extension(uint32_t base, uint16_t ext);
   uint32_t resolve_address_control(uint8_t M, uint8_t Xn);
   uint32_t resolve_address_jump(uint8_t M, uint8_t Xn);
   ResolvedAddress resolve_address(uint8_t M, uint8_t Xn, uint8_t size);

--- a/src/Emulators/PPC32Emulator.cc
+++ b/src/Emulators/PPC32Emulator.cc
@@ -5646,7 +5646,7 @@ void PPC32Emulator::exec_FC_00E_00F_fctiw_fctiwz(uint32_t op) {
   double v = this->regs.f[op_get_reg3(op)].f;
   if (v > 0x7FFFFFFF) {
     this->regs.f[op_get_reg1(op)].s = 0x000000007FFFFFFF;
-  } else if (v < -0x80000000) {
+  } else if (v < -0x80000000LL) {
     this->regs.f[op_get_reg1(op)].s = 0xFFFFFFFF80000000;
   } else if (op & 2) { // fctiwz
     this->regs.f[op_get_reg1(op)].s = static_cast<int32_t>(v);


### PR DESCRIPTION
## What this fixes

Six bugs/gaps surfaced while running real classic-Mac PPC/68K code under
`PPC32Emulator`/`M68KEmulator` (the same After Dark screensaver host from #94). All are
backed by the reference manuals and reproduced below. Each is a separate commit.

### 1. `PPC32Emulator`: `fctiw`/`fctiwz` negative saturation used an unsigned literal

`exec_FC_00E_00F_fctiw_fctiwz` clamps out-of-range operands per the PowerPC Programming
Environments Manual: values `> 2^31-1` saturate to `0x7FFF_FFFF`, values `< -2^31` saturate
to `0x8000_0000`. The low-clamp comparison was written:

```c++
} else if (v < -0x80000000) {   // 0x80000000 is unsigned int, so -0x80000000 == 0x80000000u
```

In C++ `0x80000000` doesn't fit in `int`, so it has type `unsigned int`; unary minus wraps it
back to `0x80000000u`, which converts to `+2147483648.0` in the comparison. The guard therefore
fires for **every** operand `< +2^31` — i.e. essentially all in-range values — and `fctiw(z)`
returns `0x8000_0000` (INT_MIN) instead of the converted integer.

Symptom in real software: After Dark PPC modules that truncate float pixel coordinates with
`fctiwz` (e.g. Swirling Magic, Rock Paper Scissors, Psycho Deli's palette math) collapse to a
constant, so they render blank or frozen.

Fix: give the literal the `LL` suffix so the constant is a signed 64-bit `-2^31`, matching the
`-0x80000000LL` form already used by the `convert_double_to_int` helper a few lines up in the
same file:

```c++
} else if (v < -0x80000000LL) {
```

Standalone check of the comparison (old vs new): `5.0`, `0.0`, `100.0`, `2147483646.0` all
returned `0x…80000000` under the old code and now return their correct values; the true
out-of-range inputs `-2147483649.0` → `0x…80000000` and `3000000000.0` → `0x…7FFFFFFF` are
unchanged.

### 2. `M68KEmulator`: `ADDQ`/`SUBQ` with an address-register destination

Per the M68000 Family Programmer's Reference Manual (ADDQ / SUBQ): when the destination is an
**address** register, "the entire destination address register is used regardless of the
operation size," and "the condition codes are not affected."

The `exec_5` quick-immediate path (this is the pre-existing `// TODO: when dealing with address
registers, size is ignored` case) resolved the destination with the instruction's size field, so
`addq.w #k, An` read/modified/wrote only the low 16 bits of `An` (leaving the high word stale and
dropping carry into bit 16). It also fell through to the trailing
`set_ccr_flags(this->regs.sr.get_c(), -1, -1, -1, -1)`, which writes X even for the An case,
violating "condition codes are not affected."

Symptom in real software: 68K modules that advance address-register pointers with `addq/subq`
(e.g. After Dark Deluxe's Slow Burn walking its board pointer backwards through `subq.w #n,An`)
compute wrong addresses once the low word wraps.

Fix: special-case the An destination to operate on the full 32-bit register and return before any
CCR write; the data/memory paths are unchanged.

Verification with `m68kexec`:
- `addq.w #1, A0`, `A0 = 0x0000FFFF` → `A0 = 0x00010000` (full 32-bit; was `0x00000000`), CCR
  unaffected.
- `subq.w #1, A0`, `A0 = 0x00010000` → `A0 = 0x0000FFFF` (full 32-bit), CCR unaffected.
- With X/N/C pre-set by a preceding `subq.b`, they survive the `addq.w #1, A0` unchanged
  (`xn--c` before and after).
- Regression check: `addq.w #1, D0`, `D0 = 0x0000FFFF` still gives `D0 = 0x00000000` with flags
  set — the data-register path keeps its size masking and flag behavior.

### 3. `M68KEmulator`: 68020 full extension words (bd/od, suppression, memory indirect)

`resolve_address_extension` implemented only the brief extension word and threw
`unimplemented: full extension word` (the existing `// TODO: implement this. See page 43 in the
programmers' manual`). Per the M68000PRM full-extension-word format, the full form adds: a null/
word/long base displacement, a null/word/long outer displacement, base suppress (BS) and index
suppress (IS) bits, and the memory-indirect preindexed/postindexed modes:

- no memory indirect: `base + bd + index`
- preindexed: `read_u32(base + bd + index) + od`
- postindexed: `read_u32(base + bd) + index + od`

The function now takes the base register's value as a parameter (An for mode-6 references, or
the address of the extension word for PC-relative references) and returns the full effective
address, since the memory-indirect forms have to dereference an intermediate address rather than
return an offset for the caller to add. `I/IS = 4` (reserved) throws.

Symptom in real software: any CODE resource compiled for 68020 dies immediately — e.g. After
Dark Deluxe modules use `([bd,An],Xn.l,od)`-style accesses for their C++ object tables and threw
on the first draw.

Verification with `m68kexec` (`lea.l A1, <ea>` so the computed EA lands in `A1`; `A0 = 0x2000`):
- Brief baseline unchanged: `(0x10,A0,D1.l*1)` with `D1 = 0x30` → `A1 = 0x2040`.
- Full, word bd: `(0x100,A0,D1.l*4)` with `D1 = 0x30` → `A1 = 0x21C0` (previously threw).
- Preindexed, base suppressed: `([0x3000,ZA0,D1.l])` with `D1 = 0x10`, `mem[0x3010] = 0x4444` →
  `A1 = 0x4444` (previously threw).
- Postindexed, base suppressed: `([0x3000,ZA0],D1.l)` with `D1 = 0x10`, `mem[0x3000] = 0x5000` →
  `A1 = 0x5010` (previously threw).

### 4. `M68KEmulator`: Z flag for byte/word `NOT`

`not.S` computed `value = ~read(addr, size)` without masking to the operation size, so for byte/
word operations the complement's upper bits were always nonzero and Z could never be set
(`not.b` of `0xFF` produced `0xFFFFFF00`, byte result `0x00`, but Z stayed clear). Per the PRM, Z
is set if the (size-limited) result is zero. The result is now masked to the operation size
before the write and the flag computation (the same masking `xor.S` already does).

Verification with `m68kexec`:
- `not.b D0`, `D0 = 0x000000FF` → `D0 = 0x00000000`, Z set (old: Z clear).
- `not.b D0`, `D0 = 0x123456FF` → `D0 = 0x12345600` (upper bytes preserved), Z set.
- `not.w D0`, `D0 = 0x1234FFFF` → `D0 = 0x12340000`, Z set.
- `not.b D0`, `D0 = 0x00000055` → `D0 = 0x000000AA`, N set, Z clear (unchanged).
- `not.l D0`, `D0 = 0xFFFFFFFF` → `D0 = 0x00000000`, Z set (unchanged).

### 5. `M68KEmulator`: Z/N flags for byte/word `OR`

`exec_8` computes `value = read(addr, size) | d[a].u` — the full 32 bits of `Dn`. That is correct
for the register writeback (a byte/word `or` must preserve the upper register bits), but the
flags were computed from the same unmasked value, so `or.b` with a zero byte result reported Z
clear whenever `Dn`'s upper bits were nonzero. The flags are now computed from the size-masked
result; the writeback is unchanged.

Verification with `m68kexec`:
- `or.b D0, D1`, `D0 = 0x00000000`, `D1 = 0xAAAAAA00` → `D1 = 0xAAAAAA00`, Z set (old: Z clear).
- `or.w D0, D1`, `D0 = 0x00000000`, `D1 = 0xDEAD0000` → `D1 = 0xDEAD0000`, Z set (old: Z clear).
- `or.b D0, D1`, `D0 = 0x80`, `D1 = 0` → `D1 = 0x00000080`, N set, Z clear (unchanged).
- Memory destination: `or.b D0, [A0]` with `D0 = 0xAAAAAA00`, `mem = 0x00` → memory byte `0x00`,
  Z set (old: Z clear).

### 6. `M68KEmulator`: `roxl`/`roxr` on data registers

The register forms of rotate-through-X threw `unimplemented: roxl/roxr DREG, COUNT/REG` for all
sizes, and the immediate byte form with a count of 8 threw the generic
`unimplemented: shift opcode with size=byte and shift=8`. Per the PRM (ROXL/ROXR), the operand
and the X bit together form a (size+1)-bit rotate: the effective count is the count modulo
(size+1); the register form takes the count from `Dn mod 64`; C and X get the last bit rotated
out; a count of zero leaves X unchanged and sets C **to X** (unlike the other shift/rotate
opcodes, which clear C).

Implemented as a dedicated path covering byte/word/long, immediate and register counts.

Verification with `m68kexec`:
- `roxr.b #1, D0`, `D0 = 0x01`, X=0 → `D0 = 0x00`, X=C=1, Z set.
- `roxl.b #8, D0`, `D0 = 0xFF`, X=0 → `D0 = 0x7F`, X=C=1 (9-bit rotate left 8 = rotate right 1;
  previously threw).
- `roxl.b D1, D0`, `D1 = 9` (full 9-bit period), `D0 = 0xA5` → `D0 = 0xA5` unchanged, X
  unchanged, C=X, N set (previously threw).
- `roxr.w D1, D0`, `D1 = 16`, `D0 = 0x0001`, X=0 → `D0 = 0x0002` (17-bit rotate right 16 =
  rotate left 1; previously threw).
- X propagation: `roxr.b #1, D0` (sets X) then `roxr.w #1, D0` with word 0 → `D0 = 0x8000`
  (X entered the MSB), N set.
- Regression: `lsl/lsr/rol/ror` paths untouched; the byte-count-8 guard still throws for the
  non-rox opcodes.

## Testing

- Builds cleanly (`cmake --build build`) on macOS; `resource_dasm`/`m68kexec`/`m68kdasm` link.
- All six fixes were also verified end-to-end against the real modules. The host previously
  carried workarounds for these emulator bugs (host-side `fctiwz` and `addq/subq An` shims, plus
  a local extension-word patch); rebuilding the host against this branch with every workaround
  disabled produces byte-identical frame output to the workaround builds (fctiwz: Swirling
  Magic + Rock Paper Scissors; ADDQ/SUBQ-An: Slow Burn; 68020 extension words + NOT/OR flags +
  roxl/roxr: After Dark Deluxe modules), and unrelated canary modules (Snake, Bogglins) are
  byte-identical before and after the change.

## Note on style

Written to match the conventions in 3e9fb8db ("style and logic fixes in 68k and ppc
emulators"): `static_cast`/no type-punning, `sr.get_*()` accessors, braces on every branch, terse
comments describing the operation rather than citing manual page numbers, and the `-0x80000000LL`
idiom already used for the PPC double→int conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)