### PR TITLE
Fix m68kdasm disassembly of MULU.L/MULS.L/DIVU.L/DIVS.L immediate-source forms

### DIFF
--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -2014,9 +2014,11 @@ std::string M68KEmulator::dasm_4(DisassemblyState& s) {
 
       } else if (a == 6) {
         if ((b & (~1)) == 0) {
+          // Note: This must happen before the address is resolved, since the imm data comes before any address
+          // extension words
+          uint16_t args = s.r.get_u16b();
           std::string addr = M68KEmulator::dasm_address(s, op_get_c(op), op_get_d(op), ValueType::LONG);
 
-          uint16_t args = s.r.get_u16b();
           bool is_signed = args & 0x0800;
           bool is_64bit = args & 0x0400;
           if (b & 1) {


### PR DESCRIPTION
`dasm_4()` resolves the EA before reading the extension word for the long MUL/DIV opcodes (4C00 family), but for EA mode 111/100 (immediate), resolving the EA consumes the following word(s) from the instruction stream as the immediate operand — the same word(s) that are actually the extension word (which encodes Dq/Dr/size/sign). The result is the right instruction length but wrong operands (and even the signed/unsigned mnemonic can come out wrong, since the sign bit is read from the wrong offset).

`exec_4()` already gets this right (fetches the extension word first, then resolves the EA); `dasm_4()` just had the two steps in the wrong order. This mirrors the same before-EA ordering requirement already noted for `ori`/`andi`/`xori` (line ~1335) and `move #imm` (line ~1520) elsewhere in this file.

Before:
```
00000000  4C3C 2800 1234 5678      mulu.l     D0:D5, 0x28001234
00000000  4C7C 3000 0000 00F0      divu.l     D0:D0, 0x30000000 /* '0\0\0\0' */
00000000  4C3C 2C04 1234 5678      mulu.l     D0:D5, 0x2C041234
00000000  4C7C 3C05 0000 00F0      divu.l     D0:D0, 0x3C050000
```

After:
```
00000000  4C3C 2800 1234 5678      muls.l     D2, 0x12345678
00000000  4C7C 3000 0000 00F0      divu.l     D0:D3, 0xF0
00000000  4C3C 2C04 1234 5678      muls.l     D4:D2, 0x12345678
00000000  4C7C 3C05 0000 00F0      divsl.l    D5:D3, 0xF0
```

Reference: M68000 Programmer's Reference Manual, MULU.L/MULS.L and DIVU.L/DIVS.L instruction descriptions (extension word format with Dq/Dr fields, size/sign bits, opcodes 4C00–4C7C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2Xqam6xwnLrwGp6b8Jfy3