### PR TITLE
M68KEmulator: fix the shift, rotate, compare and swap opcode families

### DIFF
--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -1725,7 +1725,9 @@ void M68KEmulator::exec_4(uint16_t opcode) {
         // b == 1
         if (M == 0) { // swap.w REG
           uint8_t reg = op_get_d(opcode);
-          this->regs.d[reg].u = (this->regs.d[reg].u >> 16) | (this->regs.d[reg].u << 16);
+          uint32_t value = (this->regs.d[reg].u >> 16) | (this->regs.d[reg].u << 16);
+          this->regs.d[reg].u = value;
+          this->regs.set_ccr_flags(-1, is_negative(value, SIZE_LONG), (value == 0), 0, 0);
           return;
         }
 

--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -2918,7 +2918,7 @@ void M68KEmulator::exec_E(uint16_t opcode) {
             case 0: // asl
             case 2: // lsl
               res = static_cast<uint16_t>(v << 1);
-              if (which == 0) { // asl sets V if the sign bit changed
+              if (op == 0) { // asl sets V if the sign bit changed
                 v_flag = (((v ^ res) >> 15) & 1);
               }
               break;
@@ -2961,21 +2961,10 @@ void M68KEmulator::exec_E(uint16_t opcode) {
   uint8_t a = op_get_a(opcode);
   uint8_t k = ((c & 3) << 1) | op_get_g(opcode);
 
-  uint8_t shift_amount;
-  if (shift_is_reg) {
-    if (size == SIZE_BYTE) {
-      shift_amount = this->regs.d[a].u & 0x00000007;
-    } else if (size == SIZE_WORD) {
-      shift_amount = this->regs.d[a].u & 0x0000000F;
-    } else {
-      shift_amount = this->regs.d[a].u & 0x0000001F;
-    }
-  } else {
-    shift_amount = (a == 0) ? 8 : a;
-    if (shift_amount == 8 && size == SIZE_BYTE && ((k & 6) != 4)) { // roxl/roxr handle a bit count of 8 below
-      throw std::runtime_error("unimplemented: shift opcode with size=byte and shift=8");
-    }
-  }
+  // The immediate form encodes counts of 1 to 8, with 8 written as 0. The register form uses the count register
+  // modulo 64, which may well exceed the operand width: a count that large is legal, and shifts the operand out
+  // entirely rather than acting as a smaller count.
+  uint8_t shift_amount = shift_is_reg ? (this->regs.d[a].u & 0x3F) : ((a == 0) ? 8 : a);
 
   switch (k) {
     case 0x00: // asr DREG, COUNT/REG
@@ -2990,22 +2979,22 @@ void M68KEmulator::exec_E(uint16_t opcode) {
       bool logical_shift = (k & 2);
       bool rotate = (k & 4);
 
+      uint8_t size_bits = bytes_for_size[size] * 8;
+      uint32_t mask = (size == SIZE_LONG) ? 0xFFFFFFFF : ((1 << size_bits) - 1);
+      uint32_t v = this->regs.d[Xn].u & mask;
+
       if (rotate && !logical_shift) { // roxl/roxr DREG, COUNT/REG
         // Rotate through the X bit: the operand and X together form a (bits + 1)-bit rotate, so the effective count
-        // is the count modulo (bits + 1). The register form uses Dn mod 64 before that reduction.
-        uint8_t size_bits = bytes_for_size[size] * 8;
-        uint32_t mask = (size == SIZE_LONG) ? 0xFFFFFFFF : ((1 << size_bits) - 1);
-        uint8_t count = shift_is_reg ? (this->regs.d[a].u & 0x3F) : shift_amount;
-        uint32_t v = this->regs.d[Xn].u & mask;
-        if (count == 0) {
+        // is the count modulo (bits + 1).
+        if (shift_amount == 0) {
           // A count of zero leaves X unchanged and sets C to X (unlike the other shift/rotate opcodes), and doesn't
           // modify the value. TODO: Technically the destination register probably should receive a write cycle; in our
           // implementation, it doesn't matter if we skip doing so (and maybe it doesn't on real hardware either;
           // verify this)
-          this->regs.sr.set_c(this->regs.sr.get_x());
+          this->regs.set_ccr_flags(-1, is_negative(v, size), (v == 0), 0, this->regs.sr.get_x());
         } else {
           bool xc = this->regs.sr.get_x();
-          for (uint8_t z = count % (size_bits + 1); z > 0; z--) {
+          for (uint8_t z = shift_amount % (size_bits + 1); z > 0; z--) {
             bool next_xc = left_shift ? ((v >> (size_bits - 1)) & 1) : (v & 1);
             if (left_shift) {
               v = ((v << 1) | xc) & mask;
@@ -3021,153 +3010,56 @@ void M68KEmulator::exec_E(uint16_t opcode) {
       }
 
       if (shift_amount == 0) {
-        this->regs.set_ccr_flags(-1, is_negative(this->regs.d[Xn].u, SIZE_LONG), (this->regs.d[Xn].u == 0), 0, 0);
-
-      } else if (size == SIZE_BYTE) {
-        uint8_t v = this->regs.d[Xn].u & 0x000000FF;
-
-        int8_t last_shifted_bit = (left_shift ? (v & (1 << (8 - shift_amount))) : (v & (1 << (shift_amount - 1))));
-
-        bool msb_changed;
-        if (!rotate && logical_shift && left_shift) {
-          uint32_t msb_values = (v >> (8 - shift_amount));
-          uint32_t mask = (1 << shift_amount) - 1;
-          msb_values &= mask;
-          msb_changed = ((msb_values == mask) || (msb_values == 0));
-        } else {
-          msb_changed = false;
-        }
-
-        if (rotate) {
-          if (logical_shift) { // rotate without extend (rol, ror)
-            if (left_shift) {
-              v = (v << shift_amount) | (v >> (8 - shift_amount));
-            } else {
-              v = (v >> shift_amount) | (v << (8 - shift_amount));
-            }
-            last_shifted_bit = -1; // X unaffected for these opcodes
-
-          } else { // rotate with extend (roxl, roxr) (TODO)
-            throw std::runtime_error("unimplemented: roxl/roxr DREG, COUNT/REG");
-          }
-
-        } else {
-          if (logical_shift) {
-            if (left_shift) {
-              v <<= shift_amount;
-            } else {
-              v >>= shift_amount;
-            }
-          } else {
-            if (left_shift) {
-              v = static_cast<int8_t>(v) << shift_amount;
-            } else {
-              v = static_cast<int8_t>(v) >> shift_amount;
-            }
-          }
-        }
-
-        this->regs.d[Xn].u = (this->regs.d[Xn].u & 0xFFFFFF00) | (v & 0x000000FF);
-        this->regs.set_ccr_flags(last_shifted_bit, (v & 0x80), (v == 0), msb_changed, last_shifted_bit);
-
-      } else if (size == SIZE_WORD) {
-        uint16_t v = this->regs.d[Xn].u & 0x0000FFFF;
-
-        int8_t last_shifted_bit = (left_shift ? (v & (1 << (16 - shift_amount))) : (v & (1 << (shift_amount - 1))));
-
-        bool msb_changed;
-        if (!rotate && logical_shift && left_shift) {
-          uint32_t msb_values = (v >> (16 - shift_amount));
-          uint32_t mask = (1 << shift_amount) - 1;
-          msb_values &= mask;
-          msb_changed = ((msb_values == mask) || (msb_values == 0));
-        } else {
-          msb_changed = false;
-        }
-
-        if (rotate) {
-          if (logical_shift) { // rotate without extend (rol, ror)
-            if (left_shift) {
-              v = (v << shift_amount) | (v >> (16 - shift_amount));
-            } else {
-              v = (v >> shift_amount) | (v << (16 - shift_amount));
-            }
-            last_shifted_bit = -1; // X unaffected for these opcodes
-
-          } else { // rotate with extend (roxl, roxr) (TODO)
-            throw std::runtime_error("unimplemented: roxl/roxr DREG, COUNT/REG");
-          }
-
-        } else {
-          if (logical_shift) {
-            if (left_shift) {
-              v <<= shift_amount;
-            } else {
-              v >>= shift_amount;
-            }
-          } else {
-            if (left_shift) {
-              v = static_cast<int16_t>(v) << shift_amount;
-            } else {
-              v = static_cast<int16_t>(v) >> shift_amount;
-            }
-          }
-        }
-
-        this->regs.d[Xn].u = (this->regs.d[Xn].u & 0xFFFF0000) | (v & 0x0000FFFF);
-        this->regs.set_ccr_flags(last_shifted_bit, (v & 0x8000), (v == 0), msb_changed, last_shifted_bit);
-
-      } else if (size == SIZE_LONG) {
-        uint32_t& target = this->regs.d[Xn].u;
-
-        int8_t last_shifted_bit =
-            (left_shift ? (target & (1 << (32 - shift_amount))) : (target & (1 << (shift_amount - 1))));
-
-        bool msb_changed;
-        if (!rotate && logical_shift && left_shift) {
-          uint32_t msb_values = (target >> (32 - shift_amount));
-          uint32_t mask = (1 << shift_amount) - 1;
-          msb_values &= mask;
-          msb_changed = ((msb_values == mask) || (msb_values == 0));
-        } else {
-          msb_changed = false;
-        }
-
-        if (rotate) {
-          if (logical_shift) { // rotate without extend (rol, ror)
-            if (left_shift) {
-              target = (target << shift_amount) | (target >> (32 - shift_amount));
-            } else {
-              target = (target >> shift_amount) | (target << (32 - shift_amount));
-            }
-            last_shifted_bit = -1; // X unaffected for these opcodes
-
-          } else { // rotate with extend (roxl, roxr) (TODO)
-            throw std::runtime_error("unimplemented: roxl/roxr DREG, COUNT/REG");
-          }
-
-        } else {
-          if (logical_shift) {
-            if (left_shift) {
-              target <<= shift_amount;
-            } else {
-              target >>= shift_amount;
-            }
-          } else {
-            if (left_shift) {
-              target = static_cast<int32_t>(target) << shift_amount;
-            } else {
-              target = static_cast<int32_t>(target) >> shift_amount;
-            }
-          }
-        }
-
-        this->regs.set_ccr_flags(
-            last_shifted_bit, (target & 0x80000000), (target == 0), msb_changed, last_shifted_bit);
-
-      } else {
-        throw std::runtime_error("invalid size for bit shift operation");
+        // A count of zero doesn't modify the value; it clears C and V, leaves X alone, and computes N and Z from the
+        // operand at the instruction's size
+        this->regs.set_ccr_flags(-1, is_negative(v, size), (v == 0), 0, 0);
+        return;
       }
+
+      bool msb_changed = false;
+      int64_t last_shifted_bit;
+      if (rotate) { // rol/ror
+        uint8_t steps = shift_amount % size_bits;
+        if (steps) {
+          v = left_shift
+              ? (((v << steps) | (v >> (size_bits - steps))) & mask)
+              : (((v >> steps) | (v << (size_bits - steps))) & mask);
+        }
+        // C is the bit that came around last, which is now at the far end of the result. A count that's a nonzero
+        // multiple of the operand width restores the original value, but still rotates a bit through C.
+        last_shifted_bit = left_shift ? (v & 1) : ((v >> (size_bits - 1)) & 1);
+
+      } else if (left_shift) { // asl/lsl
+        last_shifted_bit = (shift_amount > size_bits) ? 0 : ((v >> (size_bits - shift_amount)) & 1);
+        if (!logical_shift) {
+          // asl sets V if the MSB changed at any point during the shift, which is the case exactly when the
+          // shift_amount + 1 most significant bits of the operand aren't all equal
+          if (shift_amount >= size_bits) {
+            msb_changed = (v != 0);
+          } else {
+            uint32_t top_bits = v >> (size_bits - shift_amount - 1);
+            msb_changed = (top_bits != 0) && (top_bits != (mask >> (size_bits - shift_amount - 1)));
+          }
+        }
+        v = (shift_amount >= size_bits) ? 0 : ((v << shift_amount) & mask);
+
+      } else { // asr/lsr
+        last_shifted_bit = (shift_amount > size_bits)
+            ? (logical_shift ? 0 : ((v >> (size_bits - 1)) & 1))
+            : ((v >> (shift_amount - 1)) & 1);
+        if (logical_shift) {
+          v = (shift_amount >= size_bits) ? 0 : (v >> shift_amount);
+        } else {
+          // asr shifts copies of the sign bit in, so a count at or past the operand width fills the operand with it
+          uint8_t effective_count = (shift_amount >= size_bits) ? (size_bits - 1) : shift_amount;
+          v = static_cast<uint32_t>(sign_extend(v, size) >> effective_count) & mask;
+        }
+      }
+
+      this->regs.d[Xn].u = (this->regs.d[Xn].u & (~mask)) | v;
+      // rol/ror don't affect X; the shifts set it to the last bit shifted out, like C
+      this->regs.set_ccr_flags(
+          rotate ? -1 : last_shifted_bit, is_negative(v, size), (v == 0), msb_changed, last_shifted_bit);
       break;
     }
 

--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -305,8 +305,9 @@ void M68KEmulator::Regs::set_ccr_flags_integer_subtract(int32_t left_value, int3
   right_value = sign_extend(right_value, size);
   int32_t result = sign_extend(left_value - right_value, size);
 
-  bool overflow = (((left_value > 0) && (right_value < 0) && (result < 0)) ||
-      ((left_value < 0) && (right_value > 0) && (result > 0)));
+  // The operands' signs differ and the result's sign differs from the destination's. Comparing the signs pairwise
+  // instead misses left_value == 0 with right_value == INT_MIN, which does overflow.
+  bool overflow = (((left_value ^ right_value) & (left_value ^ result)) < 0);
   bool carry = (static_cast<uint32_t>(left_value) < static_cast<uint32_t>(right_value));
   this->set_ccr_flags(-1, (result < 0), (result == 0), overflow, carry);
 }
@@ -2599,9 +2600,18 @@ void M68KEmulator::exec_B(uint16_t opcode) {
     right_value = this->read(addr, size);
 
   } else if ((opmode & 3) == 3) { // cmpa.S AREG, ADDR
-    size = (opmode & 4) ? SIZE_LONG : SIZE_WORD;
+    // cmpa compares the entire 32-bit address register. The .w form sign-extends its source operand to 32 bits
+    // first; it does not truncate the destination to a word.
+    uint8_t src_size = (opmode & 4) ? SIZE_LONG : SIZE_WORD;
     left_value = this->regs.a[dest];
-    right_value = this->read(this->resolve_address(M, Xn, size), size);
+    right_value = sign_extend(this->read(this->resolve_address(M, Xn, src_size), src_size), src_size);
+    size = SIZE_LONG;
+
+  } else if (M == 1) { // cmpm.S [AREG]+, [AREG]+
+    size = opmode & 3;
+    // The source operand is read first, then the destination; both pointers post-increment.
+    right_value = this->read(this->resolve_address(3, Xn, size), size);
+    left_value = this->read(this->resolve_address(3, dest, size), size);
 
   } else { // xor.S DREG, ADDR  (memory ^= Dn)
     size = opmode & 3;


### PR DESCRIPTION
Eleven defects across three opcode families in `M68KEmulator`, found by differential testing while running real 68K After Dark screensaver modules under emulation (same project as #94/#95/#97). They are three independent commits; they share a PR because they are the same kind of bug in the same file, found the same way, and the compare and swap halves turned up while this branch was already open. Happy to split them again if you'd rather review them separately.

# Shift and rotate — seven defects, all in the condition codes

`asr` / `asl` / `lsr` / `lsl` / `roxr` / `roxl` / `ror` / `rol`.

**1. The shifted-out bit was truncated, so C and X were usually wrong.** `last_shifted_bit` was computed by masking the bit in place — `target & (1 << (32 - count))` — and assigned to an `int8_t`. For a long shift the isolated bit sits above bit 7 and truncates to 0, so C and X came out clear no matter what was shifted out. The word path truncates the same way, and in the byte path a shift out of bit 7 produces `-128`, which `set_ccr_flags` reads as "leave unchanged", so a byte shift that should set C leaves a stale C standing.

This is the one with a real-world reproducer. After Dark's Satori module computes log2 with a normalise-and-count loop (`moveq #31,D0` / `asl.l #1,D7` / `dbcs D0,-6`); with the carry never arriving, the loop runs all 32 iterations on every call, log2 returns a constant, and the module's potential-field generator produces the same value for every cell.

**2. The asl overflow was computed for lsl.** `msb_changed` was guarded by `(logical_shift && left_shift)`, which is lsl. The PRM gives that overflow to asl — V is set if the MSB changes at any point during the shift — and always clears V for lsl. The computation itself was also inverted (it set V when the inspected bits were all equal) and one bit short (it inspected the top `count` bits rather than `count + 1`).

**3. rol/ror never set C.** The rotate path set `last_shifted_bit = -1`, which is right for X since the plain rotates don't touch it, and then passed that same `-1` for C. C should be the last bit rotated out.

**4. The register form masked the count to the operand width.** `& 7`, `& 0xF`, `& 0x1F` instead of the PRM's `Dn` modulo 64, so `lsl.l Dc,Dd` with `Dc == 32` acted as a count of zero instead of shifting the operand out entirely. The count-of-zero path also derived N and Z from the whole 32-bit register regardless of the operation size.

Three more turned up in the same family while fixing those, and are included here:

**5. `asl.w <ea>` never set V.** The guard reads `if (which == 0)`, but `which == 0` is asr (asl is `which == 1`), and it sits inside the `which & 1` left-shift branch, so it can never be true. The intended test is on the op family: `op == 0`.

**6. size=byte with an immediate count of 8 threw.** `asl.b #8,Dn` and friends hit `unimplemented: shift opcode with size=byte and shift=8`. It's a legal encoding — the immediate field encodes counts of 1 to 8, with 8 written as 0 — and handling counts at or past the operand width covers it.

**7. roxl/roxr with a count of zero left N, Z and V standing.** That path only did `set_c(get_x())`. Per the PRM, N and Z are always set from the result (which for a zero count is the operand), and V is always cleared.

**Shape of the change.** The three copy-pasted per-size branches collapse into one size-generic block, using the `size_bits` / `mask` / `is_negative(v, size)` idiom that the adjacent roxl/roxr code already uses — that's where the deleted lines come from. It stays closed-form (no loop added), and `last_shifted_bit` becomes `int64_t`, the type `set_ccr_flags` takes, which retires the truncation in defect 1 structurally instead of case by case.

# Compare — three defects

`cmp` / `cmpa` / `cmpi` / `cmpm`.

**8. `cmpa` compared at the source operand's width, truncating the address register.** `exec_B` passed `SIZE_WORD` through to `set_ccr_flags_integer_subtract`, which sign-extends *both* operands to the size it is given — so for `cmpa.w` the 32-bit address register was cut down to its low 16 bits before the comparison. Per the PRM, `cmpa` compares all 32 bits of `An`; it is the *source* that gets sign-extended to 32 bits first. The source side was wrong in the same line for the same reason: `read()` zero-extends, so a negative word source was never sign-extended at all.

The consequence is that **any address whose low 16 bits are zero compares equal to zero.** That is the real-world reproducer for this half: After Dark's shared LIB510 runtime null-checks `NewPtrClear` with exactly this idiom —

```
01004428  A31E              syscall NewPtrClear     ; -> Ptr in A0
0100442A  2448              movea.l A2, A0
0100442C  B0FC 0000         cmpa.w  A0, #0          ; the null check
01004430  661A              bne     0100444C        ; success path
01004432  2B7C 0000 0101 EAF0  move.l [A5-0x1510], #0x101   ; else: error 0x101 -> throw
```

so an allocation that happens to land on a 64K boundary reads back as a failure. In the Deluxe "Clocks" module one allocation landed on `0x000A0000`, the constructor threw, and the module built nothing — every frame came out pure black. Padding the guest heap by two bytes made it render, which is what pointed at the comparison rather than at the module.

**9. `cmpm` was executed as `xor`.** `cmpm.S (Ay)+, (Ax)+` is encoded in `exec_B`'s opcode space as opmode 4-6 with `M == 1`, but `exec_B` had no branch for it, so it fell through into the `xor.S DREG, ADDR` branch: it performed `A[Xn] ^= D[dest]`, clobbering an address register, with no comparison and no post-increment of either pointer. `dasm_B` already decodes `cmpm` correctly, so the disassembler and the emulator disagreed about the same encoding.

**10. The subtract overflow test missed one case.** `set_ccr_flags_integer_subtract` computed V by comparing the operands' signs pairwise with strict inequalities:

```c
bool overflow = (((left_value > 0) && (right_value < 0) && (result < 0)) ||
    ((left_value < 0) && (right_value > 0) && (result > 0)));
```

`left_value == 0` with `right_value == INT_MIN` does overflow, and neither clause catches it (`left_value > 0` is false). Replaced with the sign-difference form — the operands' signs differ and the result's sign differs from the destination's. This affects every user of the helper (`cmp`, `cmpi`, `cmpa`, `sub`, `subi`, `subq`, `neg`, ...). `set_ccr_flags_integer_add` has no mirror of this defect — adding zero cannot overflow — and is left alone.

# Swap — one defect

**11. `swap` never set the condition codes.** The exchange was performed and the function returned without touching the CCR, so N, Z, V and C survived from the preceding instruction. Per the PRM, `swap` sets N from bit 31 of the *result* — which is bit 15 of the operand, not bit 31 of it — sets Z from the full 32-bit result, and clears V and C; only X is unaffected.

The stale Z is the one that bites. The 32-bit divide helpers CodeWarrior emits do `clr.w Dn / swap.w Dn / beq`, and the Z that `clr.w` leaves behind sent that branch the wrong way, so the high half of the dividend was skipped and the divide returned a wrong quotient for any dividend at or above `0x10000`.

# Verification

Two single-instruction differential harnesses run the emulator against independent reference models written from the PRM.

**Shift and rotate** — 8 opcodes x 3 sizes x {immediate count 1-8, count in register 0-63} x 24 operand values x 2 input CCRs, plus the memory form: **83,328 cases**. Against master: **34,184 disagreements** (C 17,766, RESULT 14,664, Z 14,608, V 12,784, X 8,454, N 5,180) plus 288 cases that throw. With this branch: **0**, and nothing throws.

The reference model's rules were checked back against the PRM text rather than taken on trust — ASL's "V — Set if the most significant bit is changed at any time during the shift operation", LSL's "V — Always cleared", "the shift count is the value in the data register specified in the instruction modulo 64", "a value of zero represents a count of eight", and ROL/ROR's "X — Not affected" / "C — Set according to the last bit rotated out of the operand".

**Compare** — `cmpa.w`/`cmpa.l` against four addressing modes (`#imm`, `Dn`, `An`, `(An)`) x 26 address-register values x 20 source values x 2 input CCRs, plus `cmp.b/.w/.l`, `cmpi.b/.w/.l` and `cmpm.b/.w/.l`: **17,680 cases**. The address-register values include the 64K-aligned addresses from defect 8 and the word sign-extension boundary; `cmpm` is checked on its flags *and* on both post-increments *and* on neither operand being written back to memory. Against master: **5,824 disagreements**. With this branch: **0**.

| group | mismatched before | of |
|---|---|---|
| `cmpa.w` — `#imm` / `Dn` / `An` / `(An)` | 646 each — **2,584** | 4,160 |
| `cmpa.l` — `#imm` / `Dn` / `An` / `(An)` | 2 each — **8** (defect 10 only) | 4,160 |
| `cmpm.b` / `.w` / `.l` | 1,040 each — **3,120** (every case) | 3,120 |
| `cmp.b` / `.w` / `.l` | 30 / 24 / 2 — **56** (defect 10 only) | 3,120 |
| `cmpi.b` / `.w` / `.l` | 30 / 24 / 2 — **56** (defect 10 only) | 3,120 |
| **total** | **5,824** | **17,680** |

`cmpa.l`'s width handling was already correct — its only failures are defect 10, which is also the whole of the `cmp`/`cmpi` column. Representative cases:

```
cmpa.w #imm  An=000A0000 src=00000000(->00000000)  emu ccr=04 (Z set)   ref ccr=00   <- defect 8
cmpa.w #imm  An=00000000 src=00008000(->FFFF8000)  emu ccr=09           ref ccr=01   <- source sign-extension
cmpa.l #imm  An=00000000 src=80000000(->80000000)  emu ccr=09 (V clear) ref ccr=0B   <- defect 10
cmp.b  Dn    Dn=00000000 src=00000080              emu ccr=09 (V clear) ref ccr=0B   <- defect 10
```

**Swap** — `swap.w Dn` x 8 registers x 30 register values x all 32 incoming CCRs: **7,680 cases**, checking the result, the full CCR, and that no other data or address register moves. The register values cover a zero low word with a non-zero high word (Z must stay clear), a zero high word with a non-zero low word (the `clr.w`/`swap.w` case), and bit 15 vs bit 31 set, so that taking N from the operand instead of the result is caught. Against master: **7,200 disagreements** — every one in N, Z, V or C, never in the result and never in X, which is the signature of the flags simply not being written. With this branch: **0**.

All three harnesses were re-run against the combined branch — 108,688 cases, **0 disagreements**, nothing throwing — so the three halves don't interact.

**Corpus.** As a second axis, a 61-module 68K screensaver corpus was rendered against master and against this branch: 200 frames per module, hashed on both the RGB and the palette-index plane, each module run twice per side to catch timing flakes. The host used for this carries no workarounds of its own for any of these eleven defects, so master's behaviour reaches the render unmasked.

Three of the 61 change: **Satori**, **Clocks** and **Nirvana**. The other 58 are byte-identical on both planes, with nothing unstable and 200 real frames on every side of every row. Re-running the gate with only the swap commit added and removed (its parent vs its tip) isolates that split: swap alone accounts for Clocks and Nirvana, so Satori is the shift half.

Satori is the module defect 1 repairs — on master it renders with the degenerate constant potential field described above, and on this branch it renders correctly. For Clocks and Nirvana I'll be straight about the evidence: both render healthily on *both* sides at this revision (200 of 200 distinct frames for Nirvana, 67 for Clocks, on either side), so what I can show is that the swap fix changes their output, not that it visibly repairs them. The case for defect 11 is the PRM and the 7,680-case harness; the corpus only demonstrates that the change is real, bounded, and doesn't destabilise anything.

Upstream's `ctest` suite passes. (`pop2_render` fails to build in my tree against the phosg version I have pinned, identically before and after these changes — unrelated, and CI builds it fine.)

Happy to contribute the two harnesses as `src/test_m68k_shift.cc` and `src/test_m68k_compare.cc` wired into ctest alongside `test_trap_info` if you'd like them in the tree — I left them out here to keep the PR to the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2Xqam6xwnLrwGp6b8Jfy3

