### PR TITLE
M68KEmulator: fix CMPA operand width, missing CMPM, and subtract V flag

### DIFF
--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -305,8 +305,9 @@ void M68KEmulator::Regs::set_ccr_flags_integer_subtract(int32_t left_value, int3
   right_value = sign_extend(right_value, size);
   int32_t result = sign_extend(left_value - right_value, size);
 
-  bool overflow = (((left_value > 0) && (right_value < 0) && (result < 0)) ||
-      ((left_value < 0) && (right_value > 0) && (result > 0)));
+  // The operands' signs differ and the result's sign differs from the destination's. Comparing the signs pairwise
+  // instead misses left_value == 0 with right_value == INT_MIN, which does overflow.
+  bool overflow = (((left_value ^ right_value) & (left_value ^ result)) < 0);
   bool carry = (static_cast<uint32_t>(left_value) < static_cast<uint32_t>(right_value));
   this->set_ccr_flags(-1, (result < 0), (result == 0), overflow, carry);
 }
@@ -2599,9 +2600,18 @@ void M68KEmulator::exec_B(uint16_t opcode) {
     right_value = this->read(addr, size);
 
   } else if ((opmode & 3) == 3) { // cmpa.S AREG, ADDR
-    size = (opmode & 4) ? SIZE_LONG : SIZE_WORD;
+    // cmpa compares the entire 32-bit address register. The .w form sign-extends its source operand to 32 bits
+    // first; it does not truncate the destination to a word.
+    uint8_t src_size = (opmode & 4) ? SIZE_LONG : SIZE_WORD;
     left_value = this->regs.a[dest];
-    right_value = this->read(this->resolve_address(M, Xn, size), size);
+    right_value = sign_extend(this->read(this->resolve_address(M, Xn, src_size), src_size), src_size);
+    size = SIZE_LONG;
+
+  } else if (M == 1) { // cmpm.S [AREG]+, [AREG]+
+    size = opmode & 3;
+    // The source operand is read first, then the destination; both pointers post-increment.
+    right_value = this->read(this->resolve_address(3, Xn, size), size);
+    left_value = this->read(this->resolve_address(3, dest, size), size);
 
   } else { // xor.S DREG, ADDR  (memory ^= Dn)
     size = opmode & 3;


### PR DESCRIPTION
Three defects in the M68K compare family, found by differential testing while running real 68K After Dark screensaver modules under emulation (same project as #94/#95/#97, and #99/#100 which are still open — this branch is cut from `master` and touches different code, so it doesn't conflict with either).

**1. `cmpa` compared at the source operand's width, truncating the address register.** `exec_B` passed `SIZE_WORD` through to `set_ccr_flags_integer_subtract`, which sign-extends *both* operands to the size it is given — so for `cmpa.w` the 32-bit address register was cut down to its low 16 bits before the comparison. Per the PRM, `cmpa` compares all 32 bits of `An`; it is the *source* that gets sign-extended to 32 bits first. The source side was wrong in the same line for the same reason: `read()` zero-extends, so a negative word source was never sign-extended at all.

The consequence is that **any address whose low 16 bits are zero compares equal to zero.** That is the real-world reproducer: After Dark's shared LIB510 runtime null-checks `NewPtrClear` with exactly this idiom —

```
01004428  A31E              syscall NewPtrClear     ; -> Ptr in A0
0100442A  2448              movea.l A2, A0
0100442C  B0FC 0000         cmpa.w  A0, #0          ; the null check
01004430  661A              bne     0100444C        ; success path
01004432  2B7C 0000 0101 EAF0  move.l [A5-0x1510], #0x101   ; else: error 0x101 -> throw
```

so an allocation that happens to land on a 64K boundary reads back as a failure. In the Deluxe "Clocks" module one allocation lands on `0x000A0000`, the constructor throws, and the module builds nothing — every frame came out pure black. Padding the guest heap by two bytes made it render, which is what pointed at the comparison rather than at the module.

**2. `cmpm` was executed as `xor`.** `cmpm.S (Ay)+, (Ax)+` is encoded in `exec_B`'s opcode space as opmode 4-6 with `M == 1`, but `exec_B` had no branch for it, so it fell through into the `xor.S DREG, ADDR` branch: it performed `A[Xn] ^= D[dest]`, clobbering an address register, with no comparison and no post-increment of either pointer. `dasm_B` already decodes `cmpm` correctly, so the disassembler and the emulator disagreed about the same encoding.

**3. The subtract overflow test missed one case.** `set_ccr_flags_integer_subtract` computed V by comparing the operands' signs pairwise with strict inequalities:

```c
bool overflow = (((left_value > 0) && (right_value < 0) && (result < 0)) ||
    ((left_value < 0) && (right_value > 0) && (result > 0)));
```

`left_value == 0` with `right_value == INT_MIN` does overflow, and neither clause catches it (`left_value > 0` is false). Replaced with the sign-difference form — the operands' signs differ and the result's sign differs from the destination's. This affects every user of the helper (`cmp`, `cmpi`, `cmpa`, `sub`, `subi`, `subq`, `neg`, ...). `set_ccr_flags_integer_add` has no mirror of this defect — adding zero cannot overflow — and is left alone.

**Verification.** A single-instruction differential harness runs the emulator against an independent reference model written from the PRM: `cmpa.w`/`cmpa.l` against four addressing modes (`#imm`, `Dn`, `An`, `(An)`) x 26 address-register values x 20 source values x 2 input CCRs, plus `cmp.b/.w/.l`, `cmpi.b/.w/.l` and `cmpm.b/.w/.l` — 17,680 cases. The address-register values include the 64K-aligned addresses from the bug above and the word sign-extension boundary; `cmpm` is checked on its flags *and* on both post-increments *and* on neither operand being written back.

Against `master` it reports **5,824 disagreements**; with this change, **0**.

| group | mismatched before | of |
|---|---|---|
| `cmpa.w` — `#imm` / `Dn` / `An` / `(An)` | 646 each — **2,584** | 4,160 |
| `cmpa.l` — `#imm` / `Dn` / `An` / `(An)` | 2 each — **8** (defect 3 only) | 4,160 |
| `cmpm.b` / `.w` / `.l` | 1,040 each — **3,120** (every case) | 3,120 |
| `cmp.b` / `.w` / `.l` | 30 / 24 / 2 — **56** (defect 3 only) | 3,120 |
| `cmpi.b` / `.w` / `.l` | 30 / 24 / 2 — **56** (defect 3 only) | 3,120 |
| **total** | **5,824** | **17,680** |

`cmpa.l`'s width handling was already correct — its only failures are defect 3, which is also the whole of the `cmp`/`cmpi` column. Representative cases:

```
cmpa.w #imm  An=000A0000 src=00000000(->00000000)  emu ccr=04 (Z set)   ref ccr=00   <- the bug above
cmpa.w #imm  An=00000000 src=00008000(->FFFF8000)  emu ccr=09           ref ccr=01   <- source sign-extension
cmpa.l #imm  An=00000000 src=80000000(->80000000)  emu ccr=09 (V clear) ref ccr=0B   <- defect 3
cmp.b  Dn    Dn=00000000 src=00000080              emu ccr=09 (V clear) ref ccr=0B   <- defect 3
```

As a second axis, a 61-module 68K screensaver corpus was rendered against `master` and against this branch — 200 frames per module, hashed on both the RGB and the palette-index plane, each module run twice per side to catch timing flakes. All **61/61 are byte-identical on both planes**, with nothing unstable.

That is the result I'd expect and it is worth stating plainly: on the build I measured it on, none of these modules currently trips any of the three defects. Whether the Clocks allocation lands on a 64K boundary depends on the heap layout, and unrelated changes on my side have since moved it off — two bytes of padding was always enough to flip it either way, which is exactly what makes this defect so intermittent. The corpus run is therefore evidence that the change is behaviour-preserving, not evidence that it fixes something; the differential test and the traced failure above are what establish the defects.

Upstream's `ctest` suite passes. (`pop2_render` fails to build in my tree against the phosg version I have pinned, identically before and after this change — unrelated, and CI builds it fine.)

Happy to contribute the harness as `src/test_m68k_compare.cc` wired into ctest alongside `test_trap_info` if you'd like it in the tree — I left it out here, as with #100, to keep the PR to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2Xqam6xwnLrwGp6b8Jfy3
