### PR TITLE
M68KEmulator rewrite: fix byte-immediate decode, immediate bit-op operand order, and PEA EA timing

### DIFF
--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -234,7 +234,7 @@ VisitorT::DecodeReturnT M68KEmulator::decode_instruction(VisitorT& visitor) {
             switch (size) {
               case Size::BYTE: {
                 uint16_t v = visitor.read_ins_u16(1);
-                if (v & 0xFF) {
+                if (v & 0xFF00) {
                   return DecodedAddress{
                       .mode = AM::INVALID, .invalid_reason = "bits above immediate 8-bit value are set"};
                 }
@@ -403,6 +403,17 @@ VisitorT::DecodeReturnT M68KEmulator::decode_instruction(VisitorT& visitor) {
             return visitor.on_movep(b & 1, b & 2, b, Xn, visitor.read_ins_s16(2));
           }
         } else {
+          // For the immediate forms, the bit-number word precedes the EA extension
+          // words in the instruction stream, so it must be consumed first (the
+          // read_ins_* calls are sequential).
+          uint16_t v = 0;
+          if (!(b & 4)) {
+            // 0000100000MMMRRR 00000000VVVVVVVV (DATA) btst
+            // 0000100001MMMRRR 00000000VVVVVVVV (DATA ALTERABLE) bchg
+            // 0000100010MMMRRR 00000000VVVVVVVV (DATA ALTERABLE) bclr
+            // 0000100011MMMRRR 00000000VVVVVVVV (DATA ALTERABLE) bset
+            v = visitor.read_ins_u16(1);
+          }
           auto addr = decode_address(M, Xn, Size::BYTE, false);
           if (((b & 3) == 0) ? !addr.is_data_mode() : !addr.is_data_alterable_mode()) {
             return visitor.on_invalid(nullptr, &addr);
@@ -413,17 +424,10 @@ VisitorT::DecodeReturnT M68KEmulator::decode_instruction(VisitorT& visitor) {
             // 0000RRR110MMMRRR (DATA ALTERABLE) bclr
             // 0000RRR111MMMRRR (DATA ALTERABLE) bset
             return visitor.on_btst_bchg_bclr_bset(b & 3, addr, a, 0);
+          } else if (v & 0xFF00) {
+            return visitor.on_invalid("Immediate btst/bchg/bclr/bset operation has high value bits set", &addr);
           } else {
-            // 0000100000MMMRRR 00000000VVVVVVVV (DATA) btst
-            // 0000100001MMMRRR 00000000VVVVVVVV (DATA ALTERABLE) bchg
-            // 0000100010MMMRRR 00000000VVVVVVVV (DATA ALTERABLE) bclr
-            // 0000100011MMMRRR 00000000VVVVVVVV (DATA ALTERABLE) bset
-            uint16_t v = visitor.read_ins_u16(1);
-            if (v & 0xFF00) {
-              return visitor.on_invalid("Immediate btst/bchg/bclr/bset operation has high value bits set", &addr);
-            } else {
-              return visitor.on_btst_bchg_bclr_bset(b & 3, addr, 0xFF, v);
-            }
+            return visitor.on_btst_bchg_bclr_bset(b & 3, addr, 0xFF, v);
           }
         }
 
@@ -2363,8 +2367,11 @@ std::string M68KEmulator::DisassemblyState::on_pea(const DecodedAddress& addr) {
       : std::format("pea.l      {}", this->dasm_address(addr, ValueType::LONG));
 }
 void M68KEmulator::on_pea(const DecodedAddress& addr) {
-  this->regs.a[7] -= 4;
+  // The effective address must be computed before the push: for A7-relative
+  // operands (pea (d16,A7), the take-the-address-of-a-stack-local idiom), the
+  // address register value at EA-calculation time is the pre-push A7.
   auto ea = this->resolve_memory_address(addr, Size::LONG);
+  this->regs.a[7] -= 4;
   this->write(this->regs.a[7], ea, Size::LONG);
   // Note: ccr not affected
 }


### PR DESCRIPTION
Following up on the rewrite (thanks for tackling all of the reported defects at once!) — I ran it against my 68K corpus (the After Dark screen-saver modules, which lean hard on 68020 features and SANE glue) and diffed per-frame framebuffer hashes against the pre-rewrite emulator. Three bugs surfaced, each with a minimal reproducer; this PR fixes all three. With these, all 62 programs in the corpus produce byte-identical frame-hash streams to the pre-rewrite emulator.

**1. Byte-sized immediates always rejected** (decode). `decode_address` case 7/4 for `Size::BYTE` tests `v & 0xFF` — the immediate value itself — instead of `v & 0xFF00` (the bits above it). Every nonzero `move.b #imm, <ea>` faults with "bits above immediate 8-bit value are set" (and `#0` sails through). Reproducer: `1F3C 0001` (`move.b #1, -(A7)`). m68kdasm shows the same fault since the decoder is shared.

**2. Immediate bit ops read their operands in the wrong order** (decode). For BTST/BCHG/BCLR/BSET immediate forms, the bit-number word precedes the EA extension words in the instruction stream, but the code called `decode_address` first; since the `read_ins_*` calls are sequential, the EA decode consumed the bit number and the bit-number read consumed the EA extension. Reproducer: `0838 0001 017B` (`btst #1, (0x017B).w`) — decodes as `btst #0x17B, (1).w` and faults.

**3. PEA computes its effective address after predecrementing A7** (exec). `on_pea` does `a[7] -= 4` before `resolve_memory_address`, so `pea (d16,A7)` — the take-the-address-of-a-stack-local idiom compilers emit constantly — pushes an address 4 too low. Unlike the other two this is silent corruption, no fault: in my corpus it froze one program's animation entirely and subtly degraded several others (a SANE FP68K operand pointer ended up 4 bytes off). Reproducer: `486F 0004` (`pea (4,A7)`) with A7=0x14000 pushes 0x14000; a real 68000 pushes 0x14004. (`MOVE` with an A7-relative source and `-(A7)` destination is already correct — only PEA has the ordering issue.)

Two smaller observations, not fixed here, in case you want them for the test suite:
- `NEG.B`/`NEG.W` of the most-negative value (0x80/0x8000) should set V; currently only `NEG.L` does. (The old emulator had the complementary bug — spurious V on `NEG #0` — which the rewrite fixed.)
- `NEGX` of 0 (with X clear) sets V; it shouldn't. Both old and new do this.

Also: PR #100 predates the rewrite and is superseded by it — the defect families it fixed (shift/rotate carry, CMPA.W width, CMPM, SWAP ccr) all check out correct in the rewrite against the same corpus, so I'll close it once this lands.