### PR TITLE
M68KEmulator: fix exg Dx,Ay exchanging the transposed registers

### DIFF
--- a/src/Emulators/M68KEmulator.cc
+++ b/src/Emulators/M68KEmulator.cc
@@ -3052,9 +3052,13 @@ std::string M68KEmulator::DisassemblyState::on_exg_d_a(uint8_t d_reg, uint8_t a_
   return std::format("exg        D{}, A{}", d_reg, a_reg);
 }
 void M68KEmulator::on_exg_d_a(uint8_t d_reg, uint8_t a_reg) {
-  uint32_t tmp = this->regs.a[d_reg];
-  this->regs.a[d_reg] = this->regs.d[a_reg].u;
-  this->regs.d[a_reg].u = tmp;
+  // 1100DDD110001AAA: the register in bits 9-11 is the DATA register and the
+  // one in bits 0-2 is the ADDRESS register (as the disassembler above prints).
+  // Indexing regs.a with d_reg (and regs.d with a_reg) exchanges two entirely
+  // unrelated registers.
+  uint32_t tmp = this->regs.a[a_reg];
+  this->regs.a[a_reg] = this->regs.d[d_reg].u;
+  this->regs.d[d_reg].u = tmp;
   // Note: ccr not affected
 }
 


### PR DESCRIPTION
Follow-up to #102 — this fix just missed the merge (I pushed it to the branch 25 minutes after you merged; details in [this comment](https://github.com/fuzziqersoftware/resource_dasm/pull/102#issuecomment-5323028897)).

`on_exg_d_a` indexes the address-register file with the data-register number and vice versa, so `exg D0,A5` exchanges D5 and A0. The decoder and disassembler are both correct; only the emulation body is transposed.

Reproducer: `C18D` (`exg D0,A5`) with distinct values in D0/D5/A0/A5 — currently D5 and A0 swap; after the fix D0 and A5 do.

With this plus #102, the rewrite matches my pre-rewrite validation corpus on 88 of 88 programs (except the two noted in that comment where the rewrite is right and the old emulator was wrong).